### PR TITLE
Promote AWS Audit Accelerator across marketing pages

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,7 @@ const Hero = () => {
     <section className="relative bg-gradient-to-br from-blue-900 via-blue-800 to-indigo-900 text-white overflow-hidden min-h-screen flex items-center pt-16">
       <div className="absolute inset-0 bg-black/20"></div>
       <div className="container mx-auto px-4 py-12 sm:py-20 relative z-10">
-        <motion.div 
+        <motion.div
           ref={ref}
           initial={{ opacity: 0, y: 30 }}
           animate={inView ? { opacity: 1, y: 0 } : {}}
@@ -21,34 +21,36 @@ const Hero = () => {
           className="text-center max-w-4xl mx-auto"
         >
           <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 leading-tight">
-            Innovative Software
-            <span className="text-blue-300 block mt-2">Solutions</span>
+            AWS Account Audits &
+            <span className="text-blue-300 block mt-2">Mission-Critical Software</span>
           </h1>
           <p className="text-lg sm:text-xl md:text-2xl mb-6 sm:mb-8 text-blue-100 leading-relaxed px-4">
-            We transform ideas into powerful digital solutions that drive business growth
+            Uncover hidden risk, wasted spend, and growth opportunities with our flagship AWS Audit plus executive-ready modernization roadmap.
           </p>
           <div className="mb-6 sm:mb-8">
             <div className="inline-block bg-green-500 text-white px-4 py-2 rounded-full text-sm font-semibold mb-4">
-              🚀 30-Day MVP Guarantee
+              🔍 72-Hour AWS Audit Turnaround
             </div>
           </div>
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4">
-            <Link
-              to="/contact"
+            <a
+              href="https://awsaudit.huntermussel.com"
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-gradient-to-r from-green-500 to-blue-600 hover:from-green-600 hover:to-blue-700 text-white px-8 sm:px-10 py-4 sm:py-5 rounded-lg font-bold transition-all inline-flex items-center justify-center text-sm sm:text-base shadow-xl transform hover:scale-105"
             >
-              Get Free Strategy Call
+              Book Your AWS Audit
               <ArrowRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" />
-            </Link>
+            </a>
             <Link
-              to="/free-tools"
+              to="/contact"
               className="border-2 border-blue-300 text-blue-100 hover:bg-blue-300 hover:text-blue-900 px-6 sm:px-8 py-3 sm:py-4 rounded-lg font-semibold transition-colors text-sm sm:text-base"
             >
-              Try Free Tools
+              Talk to a Cloud Architect
             </Link>
           </div>
           <p className="text-blue-200 text-sm mt-4">
-            ⚡ Average response time: 2 hours | 🛡️ No commitment required
+            ⚡ Executive briefing included | 🛡️ Led by senior AWS solutions architects
           </p>
         </motion.div>
       </div>

--- a/src/components/Plans.tsx
+++ b/src/components/Plans.tsx
@@ -12,6 +12,19 @@ interface Service {
 const Services = () => {
   const services: Service[] = [
     {
+      name: 'AWS Audit Accelerator',
+      price: 'Fixed $2,500',
+      description: '72-hour AWS account assessment + executive workshop',
+      features: [
+        '45+ point security, reliability, and cost review',
+        'Executive-ready scorecards and heat maps',
+        'Live debrief with senior AWS architect',
+        '30-60-90 day remediation roadmap',
+        'Optional implementation support add-ons'
+      ],
+      isPopular: true
+    },
+    {
       name: 'Web Development',
       price: 'From $5,000',
       description: 'Custom web applications',
@@ -35,8 +48,7 @@ const Services = () => {
         'User training',
         'Extended support',
         'Regular updates'
-      ],
-      isPopular: true
+      ]
     },
     {
       name: 'Mobile Development',
@@ -101,7 +113,7 @@ const Services = () => {
                       : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
                   } transition-colors`}
                 >
-                  Get Started
+                  {service.name === 'AWS Audit Accelerator' ? 'Book AWS Audit' : 'Get Started'}
                 </button>
               </div>
             </motion.div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import { lazy } from 'react';
 const MobileContactFlow = lazy(() => import('../components/MobileContactFlow'));
 import { Link } from 'react-router-dom';
 import { ArrowRight, Users, Calendar, FileText, Calculator, Palette, Download, CheckCircle, Star, Zap, Shield, Clock, Award, TrendingUp } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 
@@ -17,7 +18,7 @@ const Home = () => {
     "name": "Hunter Mussel",
     "url": "https://huntermussel.com",
     "logo": "https://huntermussel.com/assets/images/logo.svg",
-    "description": "Professional software development company delivering innovative, high-quality software solutions for businesses across various industries.",
+    "description": "Hunter Mussel delivers the AWS Audit Accelerator plus bespoke software development, cloud modernization, and automation services.",
     "address": {
       "@type": "PostalAddress",
       "addressCountry": "US"
@@ -31,17 +32,32 @@ const Home = () => {
       "https://github.com/huntermussel",
       "https://linkedin.com/company/huntermussel"
     ],
-    "offers": {
-      "@type": "Service",
-      "serviceType": "Software Development",
-      "provider": {
-        "@type": "Organization",
-        "name": "Hunter Mussel"
+    "offers": [
+      {
+        "@type": "Service",
+        "serviceType": "AWS Account Audit",
+        "provider": {
+          "@type": "Organization",
+          "name": "Hunter Mussel"
+        }
+      },
+      {
+        "@type": "Service",
+        "serviceType": "Custom Software Development",
+        "provider": {
+          "@type": "Organization",
+          "name": "Hunter Mussel"
+        }
       }
-    }
+    ]
   };
 
   const [ref, inView] = useInView({
+    triggerOnce: true,
+    threshold: 0.2,
+  });
+
+  const [auditRef, auditInView] = useInView({
     triggerOnce: true,
     threshold: 0.2,
   });
@@ -61,31 +77,84 @@ const Home = () => {
     threshold: 0.2,
   });
 
+  const auditDeliverables: { icon: LucideIcon; title: string; description: string }[] = [
+    {
+      icon: Shield,
+      title: 'Security & Compliance Review',
+      description: 'Pinpoint misconfigurations across IAM, VPC, GuardDuty, Shield, and encryption policies before attackers or auditors do.'
+    },
+    {
+      icon: Calculator,
+      title: 'Cost & Efficiency Optimization',
+      description: 'Spot unused resources, right-size workloads, and model immediate savings opportunities across your AWS portfolio.'
+    },
+    {
+      icon: FileText,
+      title: 'Executive-Ready Reporting',
+      description: 'Receive a concise executive summary plus a detailed technical appendix your engineering team can action immediately.'
+    },
+    {
+      icon: Users,
+      title: 'Live Strategy Workshop',
+      description: 'Walk through findings with a senior AWS architect and align leadership on a 30-60-90 day modernization roadmap.'
+    }
+  ];
+
+  const auditProcess = [
+    {
+      title: 'Kickoff & Context',
+      description: 'We meet with your stakeholders, review your architecture goals, and collect the least privilege access needed for analysis.'
+    },
+    {
+      title: 'Deep AWS Analysis',
+      description: 'Automated and manual reviews across 45+ controls with Well-Architected and CIS Benchmarks guiding our assessment.'
+    },
+    {
+      title: 'Executive Debrief',
+      description: 'A 60-minute readout with leadership and engineering to prioritize remediation, savings, and modernization initiatives.'
+    }
+  ];
+
+  const auditOutcomes = [
+    { stat: '30%', label: 'Average Immediate Cost Savings' },
+    { stat: '50+', label: 'Actionable Security & Resilience Checks' },
+    { stat: '72h', label: 'Turnaround from Kickoff to Report' }
+  ];
+
   return (
     <>
       <Helmet>
-        <title>Hunter Mussel - Professional Software Development | Custom Web & Mobile Solutions</title>
+        <title>Hunter Mussel - AWS Account Audit Experts & Custom Software Delivery</title>
         <meta
           name="description"
-          content="Hunter Mussel is a premier software development company delivering innovative web applications, mobile apps, and enterprise solutions. Get a free quote today!"
+          content="Hunter Mussel delivers the AWS Audit Accelerator plus custom web, mobile, and data solutions. Secure your AWS account, cut cloud waste, and receive an executive-ready action plan led by senior architects."
         />
-        <meta name="keywords" content="software development, web development, mobile apps, custom software, enterprise solutions, react development, node.js" />
+        <meta
+          name="keywords"
+          content="aws account audit, aws security assessment, cloud cost optimization, aws well-architected review, devops consulting, custom software development"
+        />
         <meta name="robots" content="index, follow" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
         {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://huntermussel.com/" />
-        <meta property="og:title" content="Hunter Mussel - Professional Software Development" />
-        <meta property="og:description" content="Transform your ideas into powerful digital solutions. Expert software development for web, mobile, and enterprise applications." />
+        <meta property="og:title" content="Hunter Mussel - AWS Account Audit Experts" />
+        <meta
+          property="og:description"
+          content="Book the AWS Audit Accelerator for a 72-hour review, executive briefing, and modernization roadmap. Backed by Hunter Mussel's senior cloud engineering team."
+        />
         <meta property="og:image" content="https://huntermussel.com/assets/images/hero.jpg" />
         <meta property="og:site_name" content="Hunter Mussel" />
 
         {/* Twitter */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content="https://huntermussel.com/" />
-        <meta name="twitter:title" content="Hunter Mussel - Professional Software Development" />
-        <meta name="twitter:description" content="Transform your ideas into powerful digital solutions. Expert software development for web, mobile, and enterprise applications." />
+        <meta name="twitter:title" content="Hunter Mussel - AWS Account Audit Experts" />
+        <meta
+          name="twitter:description"
+          content="Unlock AWS savings, security, and scalability with a guided audit and executive debrief from Hunter Mussel."
+        />
         <meta name="twitter:image" content="https://huntermussel.com/assets/images/hero.jpg" />
 
         {/* Canonical URL */}
@@ -99,6 +168,117 @@ const Home = () => {
 
       <main id="main-content">
         <Hero />
+
+        {/* AWS Audit Accelerator Section */}
+        <section ref={auditRef} className="py-20 bg-slate-900 text-white">
+          <div className="container mx-auto px-4">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={auditInView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.8 }}
+              className="max-w-4xl mx-auto text-center mb-16"
+            >
+              <span className="inline-flex items-center bg-blue-500/10 text-blue-200 px-4 py-2 rounded-full text-sm font-semibold uppercase tracking-wide mb-6">
+                Flagship Engagement
+              </span>
+              <h2 className="text-3xl md:text-5xl font-bold leading-tight mb-6">
+                AWS Audit Accelerator – Secure, Optimize, and Scale Your Cloud
+              </h2>
+              <p className="text-lg md:text-xl text-blue-100">
+                A 72-hour AWS account deep dive covering security, reliability, performance, and cost. You receive a prioritized remediation plan, executive-ready report, and a live briefing with a senior technical leader.
+              </p>
+            </motion.div>
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
+              {auditDeliverables.map((deliverable, index) => {
+                const Icon = deliverable.icon;
+                return (
+                  <motion.div
+                    key={deliverable.title}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={auditInView ? { opacity: 1, y: 0 } : {}}
+                    transition={{ duration: 0.7, delay: index * 0.1 }}
+                    className="bg-slate-800/60 border border-slate-700 rounded-xl p-6"
+                  >
+                    <div className="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center mb-4">
+                      <Icon className="h-6 w-6 text-blue-300" />
+                    </div>
+                    <h3 className="text-xl font-semibold mb-3">{deliverable.title}</h3>
+                    <p className="text-blue-100 text-sm leading-relaxed">{deliverable.description}</p>
+                  </motion.div>
+                );
+              })}
+            </div>
+
+            <div className="grid lg:grid-cols-5 gap-8 items-stretch">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={auditInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.8 }}
+                className="lg:col-span-2 bg-white/5 border border-slate-700 rounded-2xl p-8 backdrop-blur"
+              >
+                <h3 className="text-2xl font-semibold mb-4">What You Get</h3>
+                <ul className="space-y-4 text-blue-100 text-sm">
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    45+ point inspection across IAM, networking, data protection, and disaster recovery.
+                  </li>
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    Cost efficiency diagnostics with savings scenarios grounded in AWS Well-Architected best practices.
+                  </li>
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    Executive-ready report with heat-map prioritization, quick wins, and 30-60-90 day roadmap.
+                  </li>
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    Live executive workshop with our lead cloud architect to align stakeholders on next steps.
+                  </li>
+                </ul>
+                <a
+                  href="https://awsaudit.huntermussel.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-8 inline-flex items-center justify-center px-6 py-3 rounded-lg bg-green-500 text-slate-900 font-semibold hover:bg-green-400 transition-colors"
+                >
+                  Schedule Your AWS Audit
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </a>
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={auditInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.8, delay: 0.1 }}
+                className="lg:col-span-3 bg-slate-800/60 border border-slate-700 rounded-2xl p-8"
+              >
+                <h3 className="text-2xl font-semibold mb-6">How the Audit Works</h3>
+                <div className="space-y-6">
+                  {auditProcess.map((step, index) => (
+                    <div key={step.title} className="flex gap-4">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-500/20 border border-blue-400/40 flex items-center justify-center text-blue-200 font-semibold">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <h4 className="text-lg font-semibold mb-1">{step.title}</h4>
+                        <p className="text-sm text-blue-100 leading-relaxed">{step.description}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-8 grid sm:grid-cols-3 gap-4 text-center">
+                  {auditOutcomes.map((outcome) => (
+                    <div key={outcome.label} className="bg-slate-900/40 border border-slate-700 rounded-xl px-4 py-5">
+                      <div className="text-2xl font-bold text-blue-200 mb-1">{outcome.stat}</div>
+                      <div className="text-xs uppercase tracking-wide text-blue-300">{outcome.label}</div>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            </div>
+          </div>
+        </section>
 
         {/* Social Proof & Stats Section */}
         <section ref={statsRef} className="py-12 bg-white border-b">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,8 +1,9 @@
 import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { Link } from 'react-router-dom';
-import { ArrowRight, Users, Calendar, FileText } from 'lucide-react';
+import { ArrowRight, Users, Calendar, FileText, Shield, Calculator, Clock, CheckCircle } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
+import type { LucideIcon } from 'lucide-react';
 
 const Products = () => {
   const { ref, inView } = useInView({
@@ -10,7 +11,41 @@ const Products = () => {
     triggerOnce: true,
   });
 
-  const features = [
+  const { ref: awsRef, inView: awsInView } = useInView({
+    threshold: 0.2,
+    triggerOnce: true,
+  });
+
+  const awsAuditHighlights: { icon: LucideIcon; title: string; description: string }[] = [
+    {
+      icon: Shield,
+      title: 'Security & Compliance Hardening',
+      description: 'Find IAM, VPC, and data protection gaps before they become incidents or audit findings.'
+    },
+    {
+      icon: Calculator,
+      title: 'Cost Optimization Roadmap',
+      description: 'Model savings opportunities across reserved instances, storage, and compute waste in hours—not weeks.'
+    },
+    {
+      icon: FileText,
+      title: 'Executive Reporting Pack',
+      description: 'Receive a board-ready briefing plus a detailed technical appendix for your engineering teams.'
+    },
+    {
+      icon: Clock,
+      title: '72-Hour Turnaround',
+      description: 'Kickoff to executive meeting in three business days guided by senior AWS architects.'
+    }
+  ];
+
+  const awsAuditStats = [
+    { stat: '30%', label: 'Average Immediate Savings Identified' },
+    { stat: '50+', label: 'Controls Reviewed per Engagement' },
+    { stat: '1', label: 'Executive Strategy Session Included' }
+  ];
+
+  const odontomasterFeatures = [
     {
       icon: Users,
       title: 'Patient Management',
@@ -31,8 +66,11 @@ const Products = () => {
   return (
     <>
       <Helmet>
-        <title>Products - Hunter Mussel</title>
-        <meta name="description" content="Explore our software product line. OdontoMaster: complete dental clinic management system and more innovative solutions." />
+        <title>Products - AWS Audit Accelerator & Custom Platforms | Hunter Mussel</title>
+        <meta
+          name="description"
+          content="Discover Hunter Mussel's flagship AWS Audit Accelerator along with industry-specific platforms like OdontoMaster. Secure AWS environments, reduce spend, and deploy tailored software products."
+        />
       </Helmet>
 
       <main className="flex-1">
@@ -46,13 +84,113 @@ const Products = () => {
               transition={{ duration: 0.8 }}
               className="max-w-3xl mx-auto text-center"
             >
-              <h1 className="text-4xl font-bold text-white mb-8">
-                Our Products
+              <h1 className="text-4xl font-bold text-white mb-6">
+                Flagship Products & Cloud Programs
               </h1>
-              <p className="text-xl text-blue-100 mb-12">
-                Innovative software solutions designed for your business needs
+              <p className="text-xl text-blue-100 mb-8">
+                From the AWS Audit Accelerator to vertical-specific platforms, Hunter Mussel delivers solutions that harden security, trim spend, and accelerate innovation.
               </p>
+              <div className="flex flex-col sm:flex-row justify-center gap-4">
+                <a
+                  href="https://awsaudit.huntermussel.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center bg-white text-blue-700 font-semibold px-6 py-3 rounded-lg shadow-lg hover:bg-blue-50 transition-colors"
+                >
+                  Book the AWS Audit
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </a>
+                <Link
+                  to="/contact"
+                  className="inline-flex items-center justify-center border border-blue-100 text-blue-100 hover:bg-blue-500/20 px-6 py-3 rounded-lg font-semibold transition-colors"
+                >
+                  Talk About Custom Builds
+                </Link>
+              </div>
             </motion.div>
+          </div>
+        </section>
+
+        {/* AWS Audit Accelerator Section */}
+        <section ref={awsRef} className="py-20 bg-slate-900 text-white">
+          <div className="container mx-auto px-4">
+            <div className="grid lg:grid-cols-2 gap-12 items-start">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={awsInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.8 }}
+                className="space-y-6"
+              >
+                <span className="inline-flex items-center bg-blue-500/10 text-blue-200 px-4 py-2 rounded-full text-sm font-semibold uppercase tracking-wide">
+                  AWS Audit Accelerator
+                </span>
+                <h2 className="text-3xl font-bold leading-tight">
+                  The fastest path to an executive-ready AWS risk, reliability, and cost assessment.
+                </h2>
+                <p className="text-blue-100 text-lg">
+                  In three business days we inspect 50+ controls across security, infrastructure, data, and spend. You leave with a prioritized remediation plan and a live executive workshop led by a senior cloud architect.
+                </p>
+                <ul className="space-y-3 text-blue-100">
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    Comprehensive review mapped to AWS Well-Architected and CIS Benchmarks.
+                  </li>
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    Executive scorecards with quantified savings, risk level, and remediation effort.
+                  </li>
+                  <li className="flex items-start">
+                    <CheckCircle className="h-5 w-5 text-green-400 mr-3 mt-0.5" />
+                    30-60-90 day roadmap plus optional implementation support from our engineering squad.
+                  </li>
+                </ul>
+                <div className="flex flex-col sm:flex-row gap-4 pt-4">
+                  <a
+                    href="https://awsaudit.huntermussel.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center bg-green-500 text-slate-900 font-semibold px-6 py-3 rounded-lg shadow-lg hover:bg-green-400 transition-colors"
+                  >
+                    See Audit Packages
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </a>
+                  <Link
+                    to="/contact"
+                    className="inline-flex items-center justify-center border border-blue-200 text-blue-100 hover:bg-blue-500/20 px-6 py-3 rounded-lg font-semibold transition-colors"
+                  >
+                    Request Enterprise Quote
+                  </Link>
+                </div>
+                <div className="grid sm:grid-cols-3 gap-4 pt-6">
+                  {awsAuditStats.map((item) => (
+                    <div key={item.label} className="bg-slate-800/60 border border-slate-700 rounded-xl px-4 py-5 text-center">
+                      <div className="text-2xl font-bold text-blue-200 mb-1">{item.stat}</div>
+                      <div className="text-xs uppercase tracking-wide text-blue-300">{item.label}</div>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={awsInView ? { opacity: 1, y: 0 } : {}}
+                transition={{ duration: 0.8, delay: 0.1 }}
+                className="grid sm:grid-cols-2 gap-6"
+              >
+                {awsAuditHighlights.map((highlight) => {
+                  const Icon = highlight.icon;
+                  return (
+                    <div key={highlight.title} className="bg-slate-800/60 border border-slate-700 rounded-xl p-6">
+                      <div className="w-12 h-12 rounded-lg bg-blue-500/10 flex items-center justify-center mb-4">
+                        <Icon className="h-6 w-6 text-blue-200" />
+                      </div>
+                      <h3 className="text-xl font-semibold mb-2">{highlight.title}</h3>
+                      <p className="text-blue-100 text-sm leading-relaxed">{highlight.description}</p>
+                    </div>
+                  );
+                })}
+              </motion.div>
+            </div>
           </div>
         </section>
 
@@ -105,7 +243,7 @@ const Products = () => {
                   <div className="space-y-6">
                     <h3 className="text-xl font-semibold">Key Features</h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      {features.map((feature, index) => {
+                      {odontomasterFeatures.map((feature, index) => {
                         const Icon = feature.icon;
                         return (
                           <motion.div


### PR DESCRIPTION
## Summary
- reposition the hero and home page metadata around the AWS Audit Accelerator with new conversion-focused sections
- highlight the AWS audit program on the products page with refreshed copy, stats, and calls to action
- feature the AWS Audit Accelerator inside the services/pricing grid with dedicated deliverables and CTA

## Testing
- npm run build *(fails: existing TypeScript typing issues in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d090c940832eb7f094f051565cd5