### PR TITLE
fix: correct malformed closing tag in base64-converter How To Use sec…

### DIFF
--- a/src/pages/tools/base64-converter.astro
+++ b/src/pages/tools/base64-converter.astro
@@ -145,7 +145,7 @@ import ServiceCTA from "@/components/ServiceCTA.astro";
         <h2>How To Use</h2>
         <ul>
           <li>Select <strong>Encode</strong> or <strong>Decode</strong> mode at the top.</li>
-          <li>Choose <strong>Text</strong> for strings or <strong>File</strong} for binary files.</li>
+          <li>Choose <strong>Text</strong> for strings or <strong>File</strong> for binary files.</li>
           <li>Pick a variant and (for decode) a charset.</li>
           <li>Click <strong>Encode / Decode</strong> — output renders instantly.</li>
           <li>Copy to clipboard or download the result.</li>


### PR DESCRIPTION
…tion

<strong>File</strong} had a stray curly brace instead of closing angle bracket, rendering a visible '}' character on the page.

https://claude.ai/code/session_013CR3GxvvGprE3kdju7RJxD