### PR TITLE
feat: add Google Ads conversion tracking pixel

### DIFF
--- a/src/components/react/ContactSection.tsx
+++ b/src/components/react/ContactSection.tsx
@@ -47,6 +47,11 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
       setEmail("");
       setPhone("");
       setMessage("");
+      if (typeof window !== "undefined" && typeof (window as Window & { gtag?: (...args: unknown[]) => void }).gtag === "function") {
+        (window as Window & { gtag: (...args: unknown[]) => void }).gtag("event", "conversion", {
+          send_to: "AW-16916178576/contact_form_lead",
+        });
+      }
     } catch (err) {
       console.error("Contact form: Connection error:", err);
       setErrorMsg("I'm sorry, due the high demand we can't meet your request at moment. Hope we can talk soon.");
@@ -203,7 +208,19 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                 </div>
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <MessageCircle size={14} className="text-primary" />
-                  <a href="https://wa.me/5521995775689" target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-primary">
+                  <a
+                    href="https://wa.me/5521995775689"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors hover:text-primary"
+                    onClick={() => {
+                      if (typeof window !== "undefined" && typeof (window as Window & { gtag?: (...args: unknown[]) => void }).gtag === "function") {
+                        (window as Window & { gtag: (...args: unknown[]) => void }).gtag("event", "conversion", {
+                          send_to: "AW-16916178576/whatsapp_click_lead",
+                        });
+                      }
+                    }}
+                  >
                     WhatsApp
                   </a>
                 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -113,6 +113,7 @@ const pageSchema =
       }
       gtag("js", new Date());
       gtag("config", "G-NENC1CBCTS");
+      gtag("config", "AW-16916178576");
     </script>
     <script type="application/ld+json" set:html={JSON.stringify(pageSchema)} />
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,6 +38,16 @@ const schemaItems = Array.isArray(schema) ? schema : schema ? [schema] : [];
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-K8THDL4C');</script>
     <!-- End Google Tag Manager -->
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-NENC1CBCTS"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-NENC1CBCTS");
+      gtag("config", "AW-16916178576");
+    </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
- Add gtag('config', 'AW-16916178576') to BaseLayout.astro alongside GA4
- Add full gtag.js + GA4 + Google Ads config to Layout.astro (was missing)
- Fire conversion event on contact form submission (contact_form_lead)
- Fire conversion event on WhatsApp link click (whatsapp_click_lead)

https://claude.ai/code/session_0158UrK5gNQKKc868vDVFs1V