### PR TITLE
Add discrete Google AdSense ad units to blog and tool pages

### DIFF
--- a/src/components/AdUnit.astro
+++ b/src/components/AdUnit.astro
@@ -1,0 +1,51 @@
+---
+/**
+ * AdUnit — discrete Google AdSense ad slot.
+ *
+ * Replace ADSENSE_PUBLISHER_ID and the data-ad-slot values with your real
+ * AdSense publisher ID (ca-pub-XXXXXXXXXXXXXXXX) and slot IDs from your
+ * AdSense dashboard.
+ */
+interface Props {
+  adSlot?: string;
+  format?: "auto" | "horizontal" | "rectangle" | "vertical";
+  class?: string;
+}
+
+const {
+  adSlot = "XXXXXXXXXX",
+  format = "auto",
+  class: className = "",
+} = Astro.props;
+
+const publisherId = "ca-pub-XXXXXXXXXXXXXXXX";
+---
+
+<div class={`ad-unit ${className}`}>
+  <p class="ad-label">Advertisement · Publicidade</p>
+  <ins
+    class="adsbygoogle"
+    style="display:block"
+    data-ad-client={publisherId}
+    data-ad-slot={adSlot}
+    data-ad-format={format}
+    data-full-width-responsive="true"
+  ></ins>
+  <script is:inline>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+</div>
+
+<style>
+  .ad-unit {
+    width: 100%;
+    text-align: center;
+    margin: 2rem auto;
+  }
+  .ad-label {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: hsl(var(--muted-foreground) / 0.4);
+    margin: 0 0 0.25rem;
+    user-select: none;
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Navbar from "@/components/react/Navbar";
 import Footer from "@/components/react/Footer";
+import AdUnit from "@/components/AdUnit.astro";
 import "@/styles/globals.css";
 import "@/styles/tools.css";
 
@@ -126,6 +127,9 @@ const pageSchema =
     </script>
     <script type="application/ld+json" set:html={JSON.stringify(pageSchema)} />
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
+    <!-- Google AdSense -->
+    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
+    <!-- End Google AdSense -->
   </head>
   <body class="bg-background text-foreground min-h-screen flex flex-col font-sans antialiased selection:bg-primary/20 selection:text-primary">
     <!-- Google Tag Manager (noscript) -->
@@ -135,6 +139,9 @@ const pageSchema =
     <Navbar client:load />
     <main class="flex-1 pt-16">
       <slot />
+      <div class="container mx-auto px-6 pb-8 max-w-4xl">
+        <AdUnit adSlot="XXXXXXXXXX" format="horizontal" />
+      </div>
     </main>
     <Footer />
     <script src="/chat-widget.js" defer></script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -77,6 +77,9 @@ const schemaItems = Array.isArray(schema) ? schema : schema ? [schema] : [];
     <meta name="twitter:image" content={new URL(image, Astro.site || 'https://huntermussel.com')} />
     <meta name="twitter:site" content="@huntermussel" />
 
+    <!-- Google AdSense -->
+    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
+    <!-- End Google AdSense -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="alternate" type="text/plain" href="/llms.txt" title="LLMs.txt" />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,6 +9,7 @@ import authors from '@/data/authors.json';
 import FAQSection from '@/components/react/FAQSection';
 import { blogDevOpsFAQ, blogAIFAQ, blogCloudFAQ, blogGeneralFAQ } from '@/data/faq';
 import { articleSchema, breadcrumbSchema } from '@/lib/schema';
+import AdUnit from '@/components/AdUnit.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => data.status === 'published');
@@ -148,9 +149,13 @@ const blogSchema = [
              <Content />
           </div>
 
+          <AdUnit adSlot="XXXXXXXXXX" format="auto" class="blog-ad-mid" />
+
           <BlogShareSection client:load title={entry.data.title} url={url} />
 
           <FAQSection client:load items={faqItems} title="Frequently Asked Questions" />
+
+          <AdUnit adSlot="XXXXXXXXXX" format="horizontal" class="blog-ad-bottom" />
 
           <DisqusComments client:only="react" title={entry.data.title} identifier={entry.slug} url={url} />
        </article>


### PR DESCRIPTION
- Create AdUnit.astro reusable component with bilingual label (Advertisement · Publicidade)
- Add AdSense script to Layout.astro and BaseLayout.astro
- Blog posts: inject ad after article prose and after FAQ section
- Tool pages: inject horizontal ad at bottom of every tool page via BaseLayout
- Uses placeholder publisher ID (ca-pub-XXXXXXXXXXXXXXXX) and slot IDs (XXXXXXXXXX) to be replaced with real values from AdSense dashboard

https://claude.ai/code/session_01LtwbxEbSTB6RT1ZaHt8biB