### PR TITLE
Add Portuguese translation via React Context API at /pt/

### DIFF
--- a/src/components/react/AboutSection.tsx
+++ b/src/components/react/AboutSection.tsx
@@ -1,7 +1,11 @@
 import { motion } from "framer-motion";
 import { Linkedin, Github, Mail } from "lucide-react";
+import { useLang } from "@/context/LangContext";
+import { aboutT } from "@/data/translations";
 
 const AboutSection = () => {
+  const T = aboutT[useLang()];
+
   return (
     <section id="about" className="relative border-t border-border py-24">
       <div className="container px-6">
@@ -13,27 +17,21 @@ const AboutSection = () => {
             transition={{ duration: 0.6 }}
           >
             <span className="mb-4 inline-block font-heading text-xs font-medium uppercase tracking-widest text-primary">
-              // about
+              {T.label}
             </span>
             <h2 className="mb-6 font-heading text-3xl font-bold tracking-tight md:text-4xl">
-              Software engineering
+              {T.heading1}
               <br />
-              <span className="gradient-text">built for scale</span>
+              <span className="gradient-text">{T.heading2}</span>
             </h2>
             <p className="mb-6 font-body text-base leading-relaxed text-muted-foreground">
-              HunterMussel is a software house driven by a passion for solving
-              complex problems. We combine robust custom development, cloud
-              operations (Ops), and technical SEO to build highly scalable
-              systems.
+              {T.p1}
             </p>
             <p className="mb-6 font-body text-base leading-relaxed text-muted-foreground">
-              Operating from the Americas (GMT-3), we collaborate in real-time
-              with global teams to deliver high-impact solutions.
+              {T.p2}
             </p>
             <p className="font-body text-base leading-relaxed text-muted-foreground">
-              We don't just build software; we architect scalable infrastructure
-              and integrate AI the right way, ensuring high performance,
-              reliable operations, and strong search engine visibility.
+              {T.p3}
             </p>
           </motion.div>
 
@@ -54,10 +52,7 @@ const AboutSection = () => {
               </div>
             </div>
             <p className="mb-6 font-body text-sm leading-relaxed text-muted-foreground">
-              Software engineer with deep expertise in distributed
-              architectures, cloud operations, and SEO marketing. Passionate
-              about building scalable systems, high-performance teams, and
-              integrating AI seamlessly.
+              {T.bio}
             </p>
             <div className="flex gap-3">
               <a

--- a/src/components/react/CasesSection.tsx
+++ b/src/components/react/CasesSection.tsx
@@ -1,56 +1,9 @@
 import { motion } from "framer-motion";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Truck, GraduationCap, Globe, Users, CalendarCheck } from "lucide-react";
+import { useLang } from "@/context/LangContext";
+import { casesT } from "@/data/translations";
 
-import {
-  Truck,
-  GraduationCap,
-  Globe,
-  Users,
-  CalendarCheck,
-} from "lucide-react";
-
-const cases = [
-  {
-    icon: Truck,
-    title: "Delivery App",
-    slug: "delivery-app",
-    category: "Automation & Logistics",
-    description:
-      "AI-powered delivery app for route optimization, demand forecasting, and real-time automated order management.",
-  },
-  {
-    icon: GraduationCap,
-    title: "AI-Powered LMS",
-    slug: "ai-powered-lms",
-    category: "Education & AI",
-    description:
-      "Learning platform with AI adaptive paths, automatic grading, and student performance analytics.",
-  },
-  {
-    icon: Globe,
-    title: "Corporate Website",
-    slug: "corporate-website",
-    category: "Digital Presence",
-    description:
-      "Corporate website with advanced SEO, headless CMS, and intelligent customer service chatbot integration.",
-  },
-  {
-    icon: Users,
-    title: "Smart CRM",
-    slug: "smart-crm",
-    category: "Management & Sales",
-    description:
-      "CRM with AI lead scoring, follow-up automation, and predictive dashboards for sales teams.",
-  },
-  {
-    icon: CalendarCheck,
-    title: "Scheduling App",
-    slug: "scheduling-app",
-    category: "Productivity",
-    description:
-      "Intelligent scheduling system with AI for time optimization, automatic reminders, and availability management.",
-  },
-];
+const icons = [Truck, GraduationCap, Globe, Users, CalendarCheck];
 
 const container = {
   hidden: {},
@@ -70,6 +23,8 @@ const item = {
 };
 
 const CasesSection = () => {
+  const T = casesT[useLang()];
+
   return (
     <section
       id="cases"
@@ -84,14 +39,14 @@ const CasesSection = () => {
           className="mb-16 text-center"
         >
           <span className="mb-4 inline-block font-heading text-xs font-medium uppercase tracking-widest text-primary">
-            // cases
+            {T.label}
           </span>
           <h2 className="font-heading text-3xl font-bold tracking-tight md:text-4xl">
-            Projects We've <span className="gradient-text">Delivered</span>
+            {T.headingPre}
+            <span className="gradient-text">{T.headingHighlight}</span>
           </h2>
           <p className="mx-auto mt-4 max-w-xl font-body text-base text-muted-foreground">
-            Real solutions built with AI, automation, and cutting-edge
-            engineering.
+            {T.subtitle}
           </p>
         </motion.div>
 
@@ -102,31 +57,34 @@ const CasesSection = () => {
           viewport={{ once: true, margin: "-100px" }}
           className="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
         >
-          {cases.map((c, index) => (
-            <motion.article
-              key={c.title}
-              custom={index}
-              variants={item}
-              className="group relative overflow-hidden rounded-lg border border-border bg-card/50 transition-all hover:border-primary/30 hover:bg-card"
-            >
-              <a href={`/cases/${c.slug}/`} className="block p-6 text-current no-underline hover:no-underline">
-                <div className="mb-4 flex items-center justify-between">
-                  <div className="inline-flex rounded-md border border-border bg-muted/50 p-3 text-primary transition-all group-hover:border-glow group-hover:box-glow">
-                    <c.icon size={22} />
+          {T.items.map((c, index) => {
+            const Icon = icons[index];
+            return (
+              <motion.article
+                key={c.slug}
+                custom={index}
+                variants={item}
+                className="group relative overflow-hidden rounded-lg border border-border bg-card/50 transition-all hover:border-primary/30 hover:bg-card"
+              >
+                <a href={`/cases/${c.slug}/`} className="block p-6 text-current no-underline hover:no-underline">
+                  <div className="mb-4 flex items-center justify-between">
+                    <div className="inline-flex rounded-md border border-border bg-muted/50 p-3 text-primary transition-all group-hover:border-glow group-hover:box-glow">
+                      <Icon size={22} />
+                    </div>
+                    <span className="rounded-full border border-border bg-muted/30 px-3 py-1 font-heading text-[10px] uppercase tracking-wider text-muted-foreground">
+                      {c.category}
+                    </span>
                   </div>
-                  <span className="rounded-full border border-border bg-muted/30 px-3 py-1 font-heading text-[10px] uppercase tracking-wider text-muted-foreground">
-                    {c.category}
-                  </span>
-                </div>
-                <h3 className="mb-2 font-heading text-base font-semibold">
-                  {c.title}
-                </h3>
-                <p className="font-body text-sm leading-relaxed text-muted-foreground">
-                  {c.description}
-                </p>
-              </a>
-            </motion.article>
-          ))}
+                  <h3 className="mb-2 font-heading text-base font-semibold">
+                    {c.title}
+                  </h3>
+                  <p className="font-body text-sm leading-relaxed text-muted-foreground">
+                    {c.description}
+                  </p>
+                </a>
+              </motion.article>
+            );
+          })}
         </motion.div>
 
         <motion.div
@@ -140,7 +98,7 @@ const CasesSection = () => {
             href="/cases"
             className="inline-flex items-center gap-2 rounded-lg border border-border bg-card/50 px-6 py-2.5 font-heading text-sm font-medium text-foreground transition-all hover:border-primary/30 hover:bg-card"
           >
-            View all case studies
+            {T.viewAll}
             <ArrowRight size={16} />
           </a>
         </motion.div>

--- a/src/components/react/ContactSection.tsx
+++ b/src/components/react/ContactSection.tsx
@@ -2,8 +2,11 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import { ArrowRight, Mail, MapPin, MessageCircle } from "lucide-react";
 import CalSchedulerEmbed from "@/components/react/CalSchedulerEmbed";
+import { useLang } from "@/context/LangContext";
+import { contactT } from "@/data/translations";
 
 const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
+  const T = contactT[useLang()];
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
@@ -30,14 +33,14 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
       } else {
         const text = await res.text();
         console.error("Contact form: Received non-JSON response:", text);
-        setErrorMsg("I'm sorry, due the high demand we can't meet your request at moment. Hope we can talk soon.");
+        setErrorMsg(T.errorMsg);
         setStatus("error");
         return;
       }
 
       if (!res.ok) {
         console.error("Contact form: API Error:", data);
-        setErrorMsg("I'm sorry, due the high demand we can't meet your request at moment. Hope we can talk soon.");
+        setErrorMsg(T.errorMsg);
         setStatus("error");
         return;
       }
@@ -54,7 +57,7 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
       }
     } catch (err) {
       console.error("Contact form: Connection error:", err);
-      setErrorMsg("I'm sorry, due the high demand we can't meet your request at moment. Hope we can talk soon.");
+      setErrorMsg(T.errorMsg);
       setStatus("error");
     }
   };
@@ -72,14 +75,14 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
               className="mx-auto max-w-2xl text-center"
             >
               <span className="mb-4 inline-block font-heading text-xs font-medium uppercase tracking-widest text-primary">
-                // contact
+                {T.label}
               </span>
               <h2 className="mb-4 font-heading text-3xl font-bold tracking-tight md:text-4xl">
-                Let's Build{" "}
-                <span className="gradient-text">Together?</span>
+                {T.headingPre}
+                <span className="gradient-text">{T.headingHighlight}</span>
               </h2>
               <p className="mb-10 font-body text-base text-muted-foreground">
-                Tell us about your project. We'll respond within 24 hours.
+                {T.subtitle}
               </p>
             </motion.div>
           )}
@@ -94,19 +97,17 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
             >
               <div className="space-y-3 text-left">
                 <p className="font-heading text-lg font-semibold text-foreground">
-                  Prefer writing first?
+                  {T.preferWriting}
                 </p>
                 <p className="font-body text-sm leading-6 text-muted-foreground">
-                  Send the project context, current constraints, and what kind of
-                  outcome you need. If scheduling is easier, the live calendar is
-                  available on the right.
+                  {T.formDescription}
                 </p>
               </div>
 
               <form className="space-y-5 text-left" onSubmit={handleSubmit}>
                 {status === "success" && (
                   <p className="rounded-md border border-primary/30 bg-primary/10 px-4 py-2.5 font-body text-sm text-primary">
-                    Thank you for contacting us! Message sent. We'll respond shortly.
+                    {T.successMsg}
                   </p>
                 )}
                 {status === "error" && errorMsg && (
@@ -117,13 +118,13 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                 <div className="grid gap-5 sm:grid-cols-2">
                   <div className="sm:col-span-2">
                     <label className="mb-1.5 block font-heading text-xs text-muted-foreground">
-                      Name
+                      {T.labelName}
                     </label>
                     <input
                       type="text"
                       id="name"
                       name="name"
-                      placeholder="Your name"
+                      placeholder={T.placeholderName}
                       value={name}
                       onChange={(e) => setName(e.target.value)}
                       required
@@ -135,7 +136,7 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                   </div>
                   <div>
                     <label className="mb-1.5 block font-heading text-xs text-muted-foreground">
-                      Email
+                      {T.labelEmail}
                     </label>
                     <input
                       type="email"
@@ -153,13 +154,13 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                   </div>
                   <div>
                     <label className="mb-1.5 block font-heading text-xs text-muted-foreground">
-                      Phone (Optional)
+                      {T.labelPhone}
                     </label>
                     <input
                       type="tel"
                       id="phone"
                       name="phone"
-                      placeholder="+1 (555) 000-0000"
+                      placeholder={T.placeholderPhone}
                       value={phone}
                       onChange={(e) => setPhone(e.target.value)}
                       disabled={status === "loading"}
@@ -171,13 +172,13 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                 </div>
                 <div>
                   <label className="mb-1.5 block font-heading text-xs text-muted-foreground">
-                    Message
+                    {T.labelMessage}
                   </label>
                   <textarea
                     rows={4}
                     id="message"
                     name="message"
-                    placeholder="Describe your project..."
+                    placeholder={T.placeholderMessage}
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                     required
@@ -191,7 +192,7 @@ const ContactSection = ({ hideHeader = false }: { hideHeader?: boolean }) => {
                   disabled={status === "loading"}
                   className="group inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-6 py-3 font-heading text-sm font-semibold text-primary-foreground transition-all hover:shadow-[0_0_30px_hsl(145_80%_50%/0.3)] disabled:pointer-events-none disabled:opacity-60"
                 >
-                  {status === "loading" ? "Sending..." : "Send Message"}
+                  {status === "loading" ? T.btnSending : T.btnSend}
                   <ArrowRight
                     size={16}
                     className="transition-transform group-hover:translate-x-1"

--- a/src/components/react/HeroSection.tsx
+++ b/src/components/react/HeroSection.tsx
@@ -1,8 +1,12 @@
 import { motion } from "framer-motion";
 import { Terminal, ArrowRight } from "lucide-react";
 import heroBg from "@/assets/hero-bg.jpg";
+import { useLang } from "@/context/LangContext";
+import { heroT } from "@/data/translations";
 
 const HeroSection = () => {
+  const T = heroT[useLang()];
+
   return (
     <section className="relative flex min-h-screen items-center justify-center overflow-hidden">
       {/* Background image */}
@@ -29,22 +33,18 @@ const HeroSection = () => {
           >
             <Terminal size={14} className="text-primary" />
             <span className="font-heading text-xs text-muted-foreground">
-              AI Automation, DevOps & Software Delivery
+              {T.badge}
             </span>
           </motion.div>
 
           <h1 className="mb-6 font-heading text-4xl font-bold leading-tight tracking-tight md:text-6xl lg:text-7xl">
-            AI automation, DevOps, &
+            {T.h1a}
             <br />
-            <span className="gradient-text text-glow">
-              scalable software engineering
-            </span>
+            <span className="gradient-text text-glow">{T.h1b}</span>
           </h1>
 
           <p className="mx-auto mb-10 max-w-2xl font-body text-lg leading-relaxed text-muted-foreground md:text-xl">
-            HunterMussel designs custom software, cloud infrastructure, and AI
-            automation systems for teams that need reliable delivery, faster
-            operations, and measurable growth.
+            {T.subtitle}
           </p>
 
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
@@ -52,7 +52,7 @@ const HeroSection = () => {
               href="#contact"
               className="group inline-flex items-center gap-2 rounded-lg bg-primary px-8 py-3.5 font-heading text-sm font-semibold text-primary-foreground transition-all hover:shadow-[0_0_30px_hsl(145_80%_50%/0.3)]"
             >
-              Start Project
+              {T.cta1}
               <ArrowRight
                 size={16}
                 className="transition-transform group-hover:translate-x-1"
@@ -62,7 +62,7 @@ const HeroSection = () => {
               href="/cases"
               className="inline-flex items-center gap-2 rounded-lg border border-border bg-card/50 px-8 py-3.5 font-heading text-sm font-medium text-foreground transition-all hover:border-primary/30 hover:bg-card"
             >
-              View Case Studies
+              {T.cta2}
             </a>
           </div>
         </motion.div>
@@ -82,16 +82,12 @@ const HeroSection = () => {
           <pre className="font-heading text-xs leading-relaxed text-muted-foreground md:text-sm">
             <span className="text-primary">$</span> huntermussel system --scale
             {"\n"}
-            <span className="text-muted-foreground/60">
-              ▸ Provisioning cloud infrastructure...
-            </span>
+            <span className="text-muted-foreground/60">{T.terminal1}</span>
             {"\n"}
-            <span className="text-muted-foreground/60">
-              ▸ Deploying scalable architecture...
-            </span>
+            <span className="text-muted-foreground/60">{T.terminal2}</span>
             {"\n"}
-            <span className="text-primary">✓</span> System online with seamless
-            AI integrations 🚀
+            <span className="text-primary">✓</span>{" "}
+            {T.terminal3.replace("✓ ", "")}
           </pre>
         </motion.div>
       </div>

--- a/src/components/react/HomePage.tsx
+++ b/src/components/react/HomePage.tsx
@@ -1,0 +1,35 @@
+import { LangProvider, type Lang } from "@/context/LangContext";
+import HeroSection from "@/components/react/HeroSection";
+import ServicesSection from "@/components/react/ServicesSection";
+import CasesSection from "@/components/react/CasesSection";
+import AboutSection from "@/components/react/AboutSection";
+import TechSection from "@/components/react/TechSection";
+import ToolsSection from "@/components/react/ToolsSection";
+import FAQSection from "@/components/react/FAQSection";
+import ContactSection from "@/components/react/ContactSection";
+import { homeFAQ, homeFAQ_pt } from "@/data/faq";
+import { faqT } from "@/data/translations";
+
+interface HomePageProps {
+  lang?: Lang;
+}
+
+const HomePage = ({ lang = "en" }: HomePageProps) => {
+  const faqItems = lang === "pt" ? homeFAQ_pt : homeFAQ;
+  const faqTitle = faqT[lang].title;
+
+  return (
+    <LangProvider lang={lang}>
+      <HeroSection />
+      <ServicesSection />
+      <CasesSection />
+      <AboutSection />
+      <TechSection />
+      <ToolsSection />
+      <FAQSection items={faqItems} title={faqTitle} />
+      <ContactSection />
+    </LangProvider>
+  );
+};
+
+export default HomePage;

--- a/src/components/react/ServicesSection.tsx
+++ b/src/components/react/ServicesSection.tsx
@@ -1,6 +1,5 @@
 import { motion } from "framer-motion";
 import { ArrowRight } from "lucide-react";
-
 import {
   Brain,
   Code2,
@@ -9,51 +8,10 @@ import {
   Cloud,
   TrendingUp,
 } from "lucide-react";
+import { useLang } from "@/context/LangContext";
+import { servicesT } from "@/data/translations";
 
-const services = [
-  {
-    icon: Code2,
-    title: "Workflows & BPM",
-    slug: "workflows-bpm",
-    description:
-      "Designing the operating backbone behind scalable teams, approvals, handoffs, and automated business logic.",
-  },
-  {
-    icon: GitBranch,
-    title: "CI/CD & DevOps Engineering",
-    slug: "ci-cd-devops",
-    description:
-      "Automated delivery pipelines, infrastructure as code, and production-safe release systems for fast teams.",
-  },
-  {
-    icon: TrendingUp,
-    title: "Intelligent Automation & AI Agents",
-    slug: "intelligent-automation",
-    description:
-      "Autonomous agents, orchestrated workflows, and AI-powered task automation connected to your real systems.",
-  },
-  {
-    icon: Brain,
-    title: "AI Process Management",
-    slug: "ai-process-management",
-    description:
-      "Mapping, redesigning, and optimizing operational processes with AI-backed decision systems and measurable ROI.",
-  },
-  {
-    icon: Cloud,
-    title: "Cloud Infrastructure & AI Deployment",
-    slug: "cloud-infrastructure-ai",
-    description:
-      "Production cloud platforms for AI workloads, LLMOps, observability, and high-availability deployment patterns.",
-  },
-  {
-    icon: Shield,
-    title: "Security, Compliance & LGPD/GDPR",
-    slug: "security-compliance",
-    description:
-      "Security audits, privacy controls, encryption strategy, and compliance implementation for sensitive systems.",
-  },
-];
+const icons = [Code2, GitBranch, TrendingUp, Brain, Cloud, Shield];
 
 const container = {
   hidden: {},
@@ -72,6 +30,8 @@ const item = {
 };
 
 const ServicesSection = () => {
+  const T = servicesT[useLang()];
+
   return (
     <section id="services" className="relative py-24 overflow-hidden">
       <div className="container px-6">
@@ -83,10 +43,10 @@ const ServicesSection = () => {
           className="mb-16 text-center"
         >
           <span className="mb-4 inline-block font-heading text-xs font-medium uppercase tracking-widest text-primary">
-            // expertise
+            {T.label}
           </span>
           <h2 className="font-heading text-3xl font-bold tracking-tight md:text-4xl">
-            Services for systems, delivery, and automation
+            {T.heading}
           </h2>
         </motion.div>
 
@@ -97,29 +57,32 @@ const ServicesSection = () => {
           viewport={{ once: true, margin: "-100px" }}
           className="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
         >
-          {services.map((service, index) => (
-            <motion.div
-              key={service.title}
-              custom={index}
-              variants={item}
-              className="group rounded-lg border border-border bg-card/50 transition-all hover:border-primary/30 hover:bg-card"
-            >
-              <a
-                href={`/services/${service.slug}/`}
-                className="block p-6 text-current no-underline hover:no-underline"
+          {T.items.map((service, index) => {
+            const Icon = icons[index];
+            return (
+              <motion.div
+                key={service.slug}
+                custom={index}
+                variants={item}
+                className="group rounded-lg border border-border bg-card/50 transition-all hover:border-primary/30 hover:bg-card"
               >
-                <div className="mb-4 inline-flex rounded-md border border-border bg-muted/50 p-3 text-primary transition-all group-hover:border-glow group-hover:box-glow">
-                  <service.icon size={22} />
-                </div>
-                <h3 className="mb-2 font-heading text-base font-semibold">
-                  {service.title}
-                </h3>
-                <p className="font-body text-sm leading-relaxed text-muted-foreground">
-                  {service.description}
-                </p>
-              </a>
-            </motion.div>
-          ))}
+                <a
+                  href={`/services/${service.slug}/`}
+                  className="block p-6 text-current no-underline hover:no-underline"
+                >
+                  <div className="mb-4 inline-flex rounded-md border border-border bg-muted/50 p-3 text-primary transition-all group-hover:border-glow group-hover:box-glow">
+                    <Icon size={22} />
+                  </div>
+                  <h3 className="mb-2 font-heading text-base font-semibold">
+                    {service.title}
+                  </h3>
+                  <p className="font-body text-sm leading-relaxed text-muted-foreground">
+                    {service.description}
+                  </p>
+                </a>
+              </motion.div>
+            );
+          })}
         </motion.div>
 
         <motion.div
@@ -133,7 +96,7 @@ const ServicesSection = () => {
             href="/services"
             className="inline-flex items-center gap-2 rounded-lg border border-border bg-card/50 px-6 py-2.5 font-heading text-sm font-medium text-foreground transition-all hover:border-primary/30 hover:bg-card"
           >
-            View all services
+            {T.viewAll}
             <ArrowRight size={16} />
           </a>
         </motion.div>

--- a/src/components/react/TechSection.tsx
+++ b/src/components/react/TechSection.tsx
@@ -1,4 +1,6 @@
 import { motion } from "framer-motion";
+import { useLang } from "@/context/LangContext";
+import { techT } from "@/data/translations";
 
 const techs = [
   "OpenAI", "LangChain", "Python", "TensorFlow", "RAG",
@@ -8,6 +10,8 @@ const techs = [
 ];
 
 const TechSection = () => {
+  const T = techT[useLang()];
+
   return (
     <section id="technologies" className="relative border-t border-border py-24">
       <div className="container px-6">
@@ -22,7 +26,7 @@ const TechSection = () => {
             // stack
           </span>
           <h2 className="font-heading text-3xl font-bold tracking-tight md:text-4xl">
-            Technologies We Master
+            {T.heading}
           </h2>
         </motion.div>
 

--- a/src/components/react/ToolsSection.tsx
+++ b/src/components/react/ToolsSection.tsx
@@ -18,126 +18,27 @@ import {
   DollarSign,
   Users,
 } from "lucide-react";
+import { useLang } from "@/context/LangContext";
+import { toolsT } from "@/data/translations";
 
-const tools = [
-  {
-    icon: Sparkles,
-    title: "Prompt Optimizer",
-    slug: "prompt-optimizer",
-    category: "ai",
-    description: "5-step wizard that assembles production-ready prompts for Claude, GPT-4, Gemini and open-source models. Fully deterministic.",
-  },
-  {
-    icon: Calculator,
-    title: "Token Counter",
-    slug: "token-counter",
-    category: "ai",
-    description: "Count tokens and estimate API costs for GPT-4o, Claude, Gemini and more — in real-time, right in your browser.",
-    badge: "new",
-  },
-  {
-    icon: GitCommitHorizontal,
-    title: "Commit Message Generator",
-    slug: "commit-message-generator",
-    category: "ai",
-    description: "Step-by-step wizard to craft conventional commit messages with scope, breaking changes, and branch name suggestions.",
-    badge: "new",
-  },
-  {
-    icon: Cpu,
-    title: "AI Model Picker",
-    slug: "ai-model-picker",
-    category: "ai",
-    description: "Answer 5 questions about your use case and get the top 3 AI models ranked by fit — with pros, cons, and pricing.",
-    badge: "new",
-  },
-  {
-    icon: DollarSign,
-    title: "LLM Cost Estimator",
-    slug: "llm-cost-estimator",
-    category: "ai",
-    description: "Compare live API costs across 300+ models from OpenRouter. Enter token counts, sort by price, filter by provider.",
-    badge: "new",
-  },
-  {
-    icon: Users,
-    title: "AI Persona Picker",
-    slug: "persona-picker",
-    category: "ai",
-    description: "20 ready-made system prompt personas for engineers, writers, and analysts. Copy in one click or save your own.",
-    badge: "new",
-  },
-  {
-    icon: Binary,
-    title: "Base64 Converter",
-    slug: "base64-converter",
-    category: "encoding",
-    description: "Convert, validate, and repair Base64/Base64URL payloads fully client-side.",
-  },
-  {
-    icon: Hash,
-    title: "Hash Generator",
-    slug: "hash-generator",
-    category: "hashing",
-    description: "Generate and verify MD5, SHA-1, SHA-256, SHA-384, and SHA-512 hashes.",
-  },
-  {
-    icon: Image,
-    title: "Image Optimizer",
-    slug: "image-optimizer",
-    category: "imaging",
-    description: "Convert images to WebP in-browser. Control quality and resize — zero uploads.",
-  },
-  {
-    icon: FileText,
-    title: "Markdown Editor",
-    slug: "markdown-editor",
-    category: "writing",
-    description: "Live Markdown editor with preview, export, and formatting shortcuts.",
-  },
-  {
-    icon: ChartBar,
-    title: "Estimators",
-    slug: "estimators",
-    category: "planning",
-    description: "Project and effort estimation tools for engineering teams.",
-  },
-  {
-    icon: ScrollText,
-    title: "Log Viewer",
-    slug: "log-viewer",
-    category: "devops",
-    description: "Parse, filter, and inspect structured log files directly in the browser.",
-  },
-  {
-    icon: Lock,
-    title: "JWT Inspector",
-    slug: "jwt-inspector",
-    category: "security",
-    description: "Decode JWT tokens, inspect claims, and get live expiry countdown with security warnings.",
-  },
-  {
-    icon: ArrowLeftRight,
-    title: "YAML ↔ JSON",
-    slug: "yaml-json",
-    category: "devops",
-    description: "Bidirectional YAML and JSON converter with real-time validation. No server, no logs.",
-  },
-  {
-    icon: ShieldCheck,
-    title: "Online Linters",
-    slug: "online-linters",
-    category: "linting",
-    description: "Real-time linter for JSON, YAML, JavaScript, and Markdown powered by Monaco Editor.",
-  },
-  {
-    icon: GitCompare,
-    title: "Diff Viewer",
-    slug: "diff-viewer",
-    category: "text",
-    description: "Compare two texts side-by-side or unified — added, removed, and unchanged lines highlighted.",
-  },
-];
+const iconMap: Record<string, React.ElementType> = {
+  "prompt-optimizer": Sparkles,
+  "token-counter": Calculator,
+  "commit-message-generator": GitCommitHorizontal,
+  "ai-model-picker": Cpu,
+  "llm-cost-estimator": DollarSign,
+  "persona-picker": Users,
+  "base64-converter": Binary,
+  "hash-generator": Hash,
+  "image-optimizer": Image,
+  "markdown-editor": FileText,
+  "estimators": ChartBar,
+  "log-viewer": ScrollText,
+  "jwt-inspector": Lock,
+  "yaml-json": ArrowLeftRight,
+  "online-linters": ShieldCheck,
+  "diff-viewer": GitCompare,
+};
 
 const container = {
   hidden: {},
@@ -150,6 +51,8 @@ const item = {
 };
 
 const ToolsSection = () => {
+  const T = toolsT[useLang()];
+
   return (
     <section id="tools" className="relative py-24 overflow-hidden">
       <div className="container px-6">
@@ -161,14 +64,13 @@ const ToolsSection = () => {
           className="mb-16 text-center"
         >
           <span className="mb-4 inline-block font-heading text-xs font-medium uppercase tracking-widest text-primary">
-            // tools
+            {T.label}
           </span>
           <h2 className="font-heading text-3xl font-bold tracking-tight md:text-4xl">
-            Free Developer Tools
+            {T.heading}
           </h2>
           <p className="mx-auto mt-4 max-w-xl font-body text-sm leading-relaxed text-muted-foreground">
-            Client-side utilities for encoding, hashing, formatting, and more — no
-            account, no uploads, no tracking.
+            {T.subtitle}
           </p>
         </motion.div>
 
@@ -179,34 +81,37 @@ const ToolsSection = () => {
           viewport={{ once: true, margin: "-80px" }}
           className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
         >
-          {tools.map((tool) => (
-            <motion.a
-              key={tool.slug}
-              variants={item}
-              href={`/tools/${tool.slug}`}
-              className="group relative flex flex-col gap-3 rounded-lg border border-border bg-card/50 p-5 text-current no-underline transition-all hover:border-primary/30 hover:bg-card hover:shadow-[0_0_20px_hsl(145_80%_50%/0.08)]"
-            >
-              {tool.badge && (
-                <span className="absolute right-3 top-3 rounded-full bg-primary px-2 py-0.5 font-heading text-[0.58rem] font-bold uppercase tracking-wide text-primary-foreground">
-                  {tool.badge}
-                </span>
-              )}
-              <div className="inline-flex rounded-md border border-border bg-muted/50 p-2.5 text-primary transition-all group-hover:border-glow group-hover:box-glow w-fit">
-                <tool.icon size={18} />
-              </div>
-              <div>
-                <span className="mb-1 inline-block font-heading text-[0.65rem] font-medium uppercase tracking-widest text-muted-foreground">
-                  // {tool.category}
-                </span>
-                <h3 className="font-heading text-sm font-semibold text-foreground">
-                  {tool.title}
-                </h3>
-                <p className="mt-1 font-body text-xs leading-relaxed text-muted-foreground">
-                  {tool.description}
-                </p>
-              </div>
-            </motion.a>
-          ))}
+          {T.items.map((tool) => {
+            const Icon = iconMap[tool.slug] ?? Clock;
+            return (
+              <motion.a
+                key={tool.slug}
+                variants={item}
+                href={`/tools/${tool.slug}`}
+                className="group relative flex flex-col gap-3 rounded-lg border border-border bg-card/50 p-5 text-current no-underline transition-all hover:border-primary/30 hover:bg-card hover:shadow-[0_0_20px_hsl(145_80%_50%/0.08)]"
+              >
+                {tool.badge && (
+                  <span className="absolute right-3 top-3 rounded-full bg-primary px-2 py-0.5 font-heading text-[0.58rem] font-bold uppercase tracking-wide text-primary-foreground">
+                    {tool.badge}
+                  </span>
+                )}
+                <div className="inline-flex rounded-md border border-border bg-muted/50 p-2.5 text-primary transition-all group-hover:border-glow group-hover:box-glow w-fit">
+                  <Icon size={18} />
+                </div>
+                <div>
+                  <span className="mb-1 inline-block font-heading text-[0.65rem] font-medium uppercase tracking-widest text-muted-foreground">
+                    // {tool.category}
+                  </span>
+                  <h3 className="font-heading text-sm font-semibold text-foreground">
+                    {tool.title}
+                  </h3>
+                  <p className="mt-1 font-body text-xs leading-relaxed text-muted-foreground">
+                    {tool.description}
+                  </p>
+                </div>
+              </motion.a>
+            );
+          })}
         </motion.div>
 
         <motion.div
@@ -220,7 +125,7 @@ const ToolsSection = () => {
             href="/tools"
             className="inline-flex items-center gap-2 rounded-lg border border-border bg-card/50 px-6 py-2.5 font-heading text-sm font-medium text-foreground transition-all hover:border-primary/30 hover:bg-card"
           >
-            View all tools →
+            {T.viewAll}
           </a>
         </motion.div>
       </div>

--- a/src/context/LangContext.tsx
+++ b/src/context/LangContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+export type Lang = "en" | "pt";
+
+const LangContext = createContext<Lang>("en");
+
+export const LangProvider = ({
+  lang,
+  children,
+}: {
+  lang: Lang;
+  children: React.ReactNode;
+}) => <LangContext.Provider value={lang}>{children}</LangContext.Provider>;
+
+export const useLang = () => useContext(LangContext);

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -56,6 +56,59 @@ export const homeFAQ: FAQItem[] = [
   },
 ];
 
+export const homeFAQ_pt: FAQItem[] = [
+  {
+    question: "O que é a HunterMussel?",
+    answer:
+      "HunterMussel é uma software house especializada em DevOps, automação com IA e engenharia de software escalável. Ajudamos times que precisam de entrega confiável, infraestrutura robusta em nuvem e IA integrada a sistemas reais — não apenas demos.",
+  },
+  {
+    question: "Com quem vocês trabalham?",
+    answer:
+      "Principalmente scale-ups e startups com captação que precisam escalar tecnologia sem montar um grande time interno. Também trabalhamos com equipes de engenharia em empresas consolidadas que buscam modernizar sua infraestrutura e pipelines de entrega.",
+  },
+  {
+    question: "Vocês atendem clientes internacionais?",
+    answer:
+      "Sim. Operamos no GMT-3 e colaboramos em tempo real com times nos EUA, Europa e América Latina. Toda documentação e comunicação de projetos internacionais é entregue em inglês.",
+  },
+  {
+    question: "A HunterMussel é freelancer ou agência?",
+    answer:
+      "Nenhum dos dois no sentido tradicional. Operamos como parceiro técnico — um time pequeno, sênior, que trabalha próximo à sua engenharia. Sem gerentes de conta no meio. Você fala diretamente com quem está construindo.",
+  },
+  {
+    question: "Como começa um novo projeto?",
+    answer:
+      "Começamos com uma sessão diagnóstica gratuita para entender seu contexto técnico, gargalos atuais e objetivos. A partir daí, entregamos uma proposta com escopo, prazo e modelo de engajamento (projeto de escopo fechado ou retainer mensal).",
+  },
+  {
+    question: "Quanto custa contratar a HunterMussel?",
+    answer:
+      "Depende do escopo. Projetos de escopo fechado começam em R$ 8.000. Retainers mensais para DevOps e automação variam de R$ 5.000 a R$ 18.000 dependendo da complexidade e horas dedicadas. Fazemos um diagnóstico gratuito antes de qualquer proposta.",
+  },
+  {
+    question: "Vocês trabalham com projetos fechados ou retainer mensal?",
+    answer:
+      "Os dois. Escopo fechado para entregas definidas como implementação de CI/CD, migração de infraestrutura ou setup de agente de IA. Retainer para times que precisam de suporte contínuo em DevOps, evolução de automações e melhoria contínua de entrega.",
+  },
+  {
+    question: "Com quais tecnologias vocês trabalham?",
+    answer:
+      "AWS, GCP, Docker, Kubernetes, Terraform, GitHub Actions, Python, Go, Node.js, React, OpenAI, LangChain, n8n, Zapier — entre outras. As decisões de stack são guiadas pelo que melhor se adapta ao projeto, não por preferência arbitrária.",
+  },
+  {
+    question: "Vocês trabalham com IA generativa?",
+    answer:
+      "Sim. Construímos agentes autônomos, workflows orquestrados por LLM e integrações de IA em sistemas existentes. Trabalhamos com OpenAI, LangChain, pipelines RAG e práticas de LLMOps para ambientes de produção.",
+  },
+  {
+    question: "Vocês assinam NDA?",
+    answer:
+      "Sim, sempre. Acordos de confidencialidade são padrão antes de qualquer conversa de scoping técnico.",
+  },
+];
+
 export const serviceFAQ: Record<string, FAQItem[]> = {
   "ci-cd-devops": [
     {

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -1,0 +1,567 @@
+import type { Lang } from "@/context/LangContext";
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+export const heroT = {
+  en: {
+    badge: "AI Automation, DevOps & Software Delivery",
+    h1a: "AI automation, DevOps, &",
+    h1b: "scalable software engineering",
+    subtitle:
+      "HunterMussel designs custom software, cloud infrastructure, and AI automation systems for teams that need reliable delivery, faster operations, and measurable growth.",
+    cta1: "Start Project",
+    cta2: "View Case Studies",
+    terminal1: "▸ Provisioning cloud infrastructure...",
+    terminal2: "▸ Deploying scalable architecture...",
+    terminal3: "✓ System online with seamless AI integrations 🚀",
+  },
+  pt: {
+    badge: "Automação com IA, DevOps & Entrega de Software",
+    h1a: "Automação com IA, DevOps e",
+    h1b: "engenharia de software escalável",
+    subtitle:
+      "HunterMussel projeta software personalizado, infraestrutura em nuvem e sistemas de automação com IA para equipes que precisam de entrega confiável, operações mais ágeis e crescimento mensurável.",
+    cta1: "Iniciar Projeto",
+    cta2: "Ver Cases",
+    terminal1: "▸ Provisionando infraestrutura em nuvem...",
+    terminal2: "▸ Implantando arquitetura escalável...",
+    terminal3: "✓ Sistema online com integrações de IA 🚀",
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// Services
+// ---------------------------------------------------------------------------
+export const servicesT = {
+  en: {
+    label: "// expertise",
+    heading: "Services for systems, delivery, and automation",
+    viewAll: "View all services",
+    items: [
+      {
+        title: "Workflows & BPM",
+        slug: "workflows-bpm",
+        description:
+          "Designing the operating backbone behind scalable teams, approvals, handoffs, and automated business logic.",
+      },
+      {
+        title: "CI/CD & DevOps Engineering",
+        slug: "ci-cd-devops",
+        description:
+          "Automated delivery pipelines, infrastructure as code, and production-safe release systems for fast teams.",
+      },
+      {
+        title: "Intelligent Automation & AI Agents",
+        slug: "intelligent-automation",
+        description:
+          "Autonomous agents, orchestrated workflows, and AI-powered task automation connected to your real systems.",
+      },
+      {
+        title: "AI Process Management",
+        slug: "ai-process-management",
+        description:
+          "Mapping, redesigning, and optimizing operational processes with AI-backed decision systems and measurable ROI.",
+      },
+      {
+        title: "Cloud Infrastructure & AI Deployment",
+        slug: "cloud-infrastructure-ai",
+        description:
+          "Production cloud platforms for AI workloads, LLMOps, observability, and high-availability deployment patterns.",
+      },
+      {
+        title: "Security, Compliance & LGPD/GDPR",
+        slug: "security-compliance",
+        description:
+          "Security audits, privacy controls, encryption strategy, and compliance implementation for sensitive systems.",
+      },
+    ],
+  },
+  pt: {
+    label: "// expertise",
+    heading: "Serviços para sistemas, entrega e automação",
+    viewAll: "Ver todos os serviços",
+    items: [
+      {
+        title: "Workflows & BPM",
+        slug: "workflows-bpm",
+        description:
+          "Desenhando a espinha dorsal operacional de equipes escaláveis, aprovações, handoffs e lógica de negócio automatizada.",
+      },
+      {
+        title: "CI/CD & Engenharia DevOps",
+        slug: "ci-cd-devops",
+        description:
+          "Pipelines de entrega automatizados, infraestrutura como código e sistemas de deploy seguros para times ágeis.",
+      },
+      {
+        title: "Automação Inteligente & Agentes de IA",
+        slug: "intelligent-automation",
+        description:
+          "Agentes autônomos, workflows orquestrados e automação de tarefas com IA conectados aos seus sistemas reais.",
+      },
+      {
+        title: "Gestão de Processos com IA",
+        slug: "ai-process-management",
+        description:
+          "Mapeamento, redesenho e otimização de processos operacionais com sistemas de decisão baseados em IA e ROI mensurável.",
+      },
+      {
+        title: "Infraestrutura em Nuvem & Deploy de IA",
+        slug: "cloud-infrastructure-ai",
+        description:
+          "Plataformas em nuvem para workloads de IA, LLMOps, observabilidade e padrões de alta disponibilidade.",
+      },
+      {
+        title: "Segurança, Compliance & LGPD/GDPR",
+        slug: "security-compliance",
+        description:
+          "Auditorias de segurança, controles de privacidade, estratégia de criptografia e implementação de compliance para sistemas sensíveis.",
+      },
+    ],
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// About
+// ---------------------------------------------------------------------------
+export const aboutT = {
+  en: {
+    label: "// about",
+    heading1: "Software engineering",
+    heading2: "built for scale",
+    p1: "HunterMussel is a software house driven by a passion for solving complex problems. We combine robust custom development, cloud operations (Ops), and technical SEO to build highly scalable systems.",
+    p2: "Operating from the Americas (GMT-3), we collaborate in real-time with global teams to deliver high-impact solutions.",
+    p3: "We don't just build software; we architect scalable infrastructure and integrate AI the right way, ensuring high performance, reliable operations, and strong search engine visibility.",
+    bio: "Software engineer with deep expertise in distributed architectures, cloud operations, and SEO marketing. Passionate about building scalable systems, high-performance teams, and integrating AI seamlessly.",
+  },
+  pt: {
+    label: "// sobre",
+    heading1: "Engenharia de software",
+    heading2: "construída para escalar",
+    p1: "HunterMussel é uma software house movida pela paixão em resolver problemas complexos. Combinamos desenvolvimento personalizado, operações em nuvem (Ops) e SEO técnico para construir sistemas altamente escaláveis.",
+    p2: "Atuando das Américas (GMT-3), colaboramos em tempo real com equipes globais para entregar soluções de alto impacto.",
+    p3: "Não construímos apenas software; arquitetamos infraestrutura escalável e integramos IA do jeito certo, garantindo alta performance, operações confiáveis e forte visibilidade nos mecanismos de busca.",
+    bio: "Engenheiro de software com profunda expertise em arquiteturas distribuídas, operações em nuvem e marketing de SEO. Apaixonado por construir sistemas escaláveis, times de alta performance e integração de IA de forma eficiente.",
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+export const casesT = {
+  en: {
+    label: "// cases",
+    headingPre: "Projects We've ",
+    headingHighlight: "Delivered",
+    subtitle:
+      "Real solutions built with AI, automation, and cutting-edge engineering.",
+    viewAll: "View all case studies",
+    items: [
+      {
+        title: "Delivery App",
+        slug: "delivery-app",
+        category: "Automation & Logistics",
+        description:
+          "AI-powered delivery app for route optimization, demand forecasting, and real-time automated order management.",
+      },
+      {
+        title: "AI-Powered LMS",
+        slug: "ai-powered-lms",
+        category: "Education & AI",
+        description:
+          "Learning platform with AI adaptive paths, automatic grading, and student performance analytics.",
+      },
+      {
+        title: "Corporate Website",
+        slug: "corporate-website",
+        category: "Digital Presence",
+        description:
+          "Corporate website with advanced SEO, headless CMS, and intelligent customer service chatbot integration.",
+      },
+      {
+        title: "Smart CRM",
+        slug: "smart-crm",
+        category: "Management & Sales",
+        description:
+          "CRM with AI lead scoring, follow-up automation, and predictive dashboards for sales teams.",
+      },
+      {
+        title: "Scheduling App",
+        slug: "scheduling-app",
+        category: "Productivity",
+        description:
+          "Intelligent scheduling system with AI for time optimization, automatic reminders, and availability management.",
+      },
+    ],
+  },
+  pt: {
+    label: "// cases",
+    headingPre: "Projetos que ",
+    headingHighlight: "Entregamos",
+    subtitle:
+      "Soluções reais construídas com IA, automação e engenharia de ponta.",
+    viewAll: "Ver todos os cases",
+    items: [
+      {
+        title: "App de Delivery",
+        slug: "delivery-app",
+        category: "Automação & Logística",
+        description:
+          "App de delivery com IA para otimização de rotas, previsão de demanda e gestão automatizada de pedidos em tempo real.",
+      },
+      {
+        title: "LMS com IA",
+        slug: "ai-powered-lms",
+        category: "Educação & IA",
+        description:
+          "Plataforma de ensino com trilhas adaptativas por IA, correção automática e analytics de desempenho dos alunos.",
+      },
+      {
+        title: "Site Corporativo",
+        slug: "corporate-website",
+        category: "Presença Digital",
+        description:
+          "Site corporativo com SEO avançado, CMS headless e chatbot inteligente para atendimento ao cliente.",
+      },
+      {
+        title: "CRM Inteligente",
+        slug: "smart-crm",
+        category: "Gestão & Vendas",
+        description:
+          "CRM com scoring de leads por IA, automação de follow-up e dashboards preditivos para equipes de vendas.",
+      },
+      {
+        title: "App de Agendamento",
+        slug: "scheduling-app",
+        category: "Produtividade",
+        description:
+          "Sistema de agendamento inteligente com IA para otimização de horários, lembretes automáticos e gestão de disponibilidade.",
+      },
+    ],
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// Tech
+// ---------------------------------------------------------------------------
+export const techT = {
+  en: { heading: "Technologies We Master" },
+  pt: { heading: "Tecnologias que Dominamos" },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+export const toolsT = {
+  en: {
+    label: "// tools",
+    heading: "Free Developer Tools",
+    subtitle:
+      "Client-side utilities for encoding, hashing, formatting, and more — no account, no uploads, no tracking.",
+    viewAll: "View all tools →",
+    items: [
+      {
+        slug: "prompt-optimizer",
+        title: "Prompt Optimizer",
+        category: "ai",
+        description:
+          "5-step wizard that assembles production-ready prompts for Claude, GPT-4, Gemini and open-source models. Fully deterministic.",
+      },
+      {
+        slug: "token-counter",
+        title: "Token Counter",
+        category: "ai",
+        description:
+          "Count tokens and estimate API costs for GPT-4o, Claude, Gemini and more — in real-time, right in your browser.",
+        badge: "new",
+      },
+      {
+        slug: "commit-message-generator",
+        title: "Commit Message Generator",
+        category: "ai",
+        description:
+          "Step-by-step wizard to craft conventional commit messages with scope, breaking changes, and branch name suggestions.",
+        badge: "new",
+      },
+      {
+        slug: "ai-model-picker",
+        title: "AI Model Picker",
+        category: "ai",
+        description:
+          "Answer 5 questions about your use case and get the top 3 AI models ranked by fit — with pros, cons, and pricing.",
+        badge: "new",
+      },
+      {
+        slug: "llm-cost-estimator",
+        title: "LLM Cost Estimator",
+        category: "ai",
+        description:
+          "Compare live API costs across 300+ models from OpenRouter. Enter token counts, sort by price, filter by provider.",
+        badge: "new",
+      },
+      {
+        slug: "persona-picker",
+        title: "AI Persona Picker",
+        category: "ai",
+        description:
+          "20 ready-made system prompt personas for engineers, writers, and analysts. Copy in one click or save your own.",
+        badge: "new",
+      },
+      {
+        slug: "base64-converter",
+        title: "Base64 Converter",
+        category: "encoding",
+        description:
+          "Convert, validate, and repair Base64/Base64URL payloads fully client-side.",
+      },
+      {
+        slug: "hash-generator",
+        title: "Hash Generator",
+        category: "hashing",
+        description:
+          "Generate and verify MD5, SHA-1, SHA-256, SHA-384, and SHA-512 hashes.",
+      },
+      {
+        slug: "image-optimizer",
+        title: "Image Optimizer",
+        category: "imaging",
+        description:
+          "Convert images to WebP in-browser. Control quality and resize — zero uploads.",
+      },
+      {
+        slug: "markdown-editor",
+        title: "Markdown Editor",
+        category: "writing",
+        description:
+          "Live Markdown editor with preview, export, and formatting shortcuts.",
+      },
+      {
+        slug: "estimators",
+        title: "Estimators",
+        category: "planning",
+        description:
+          "Project and effort estimation tools for engineering teams.",
+      },
+      {
+        slug: "log-viewer",
+        title: "Log Viewer",
+        category: "devops",
+        description:
+          "Parse, filter, and inspect structured log files directly in the browser.",
+      },
+      {
+        slug: "jwt-inspector",
+        title: "JWT Inspector",
+        category: "security",
+        description:
+          "Decode JWT tokens, inspect claims, and get live expiry countdown with security warnings.",
+      },
+      {
+        slug: "yaml-json",
+        title: "YAML ↔ JSON",
+        category: "devops",
+        description:
+          "Bidirectional YAML and JSON converter with real-time validation. No server, no logs.",
+      },
+      {
+        slug: "online-linters",
+        title: "Online Linters",
+        category: "linting",
+        description:
+          "Real-time linter for JSON, YAML, JavaScript, and Markdown powered by Monaco Editor.",
+      },
+      {
+        slug: "diff-viewer",
+        title: "Diff Viewer",
+        category: "text",
+        description:
+          "Compare two texts side-by-side or unified — added, removed, and unchanged lines highlighted.",
+      },
+    ],
+  },
+  pt: {
+    label: "// tools",
+    heading: "Ferramentas Gratuitas para Desenvolvedores",
+    subtitle:
+      "Utilitários client-side para encoding, hashing, formatação e muito mais — sem conta, sem uploads, sem rastreamento.",
+    viewAll: "Ver todas as ferramentas →",
+    items: [
+      {
+        slug: "prompt-optimizer",
+        title: "Otimizador de Prompts",
+        category: "ai",
+        description:
+          "Wizard em 5 etapas que monta prompts prontos para produção para Claude, GPT-4, Gemini e modelos open-source. Totalmente determinístico.",
+      },
+      {
+        slug: "token-counter",
+        title: "Contador de Tokens",
+        category: "ai",
+        description:
+          "Conte tokens e estime custos de API para GPT-4o, Claude, Gemini e mais — em tempo real, direto no navegador.",
+        badge: "new",
+      },
+      {
+        slug: "commit-message-generator",
+        title: "Gerador de Mensagens de Commit",
+        category: "ai",
+        description:
+          "Wizard passo a passo para criar mensagens de commit convencionais com escopo, breaking changes e sugestões de nome de branch.",
+        badge: "new",
+      },
+      {
+        slug: "ai-model-picker",
+        title: "Seletor de Modelo de IA",
+        category: "ai",
+        description:
+          "Responda 5 perguntas sobre seu caso de uso e obtenha os 3 principais modelos de IA ranqueados por adequação — com prós, contras e preços.",
+        badge: "new",
+      },
+      {
+        slug: "llm-cost-estimator",
+        title: "Estimador de Custo de LLM",
+        category: "ai",
+        description:
+          "Compare custos de API em tempo real de 300+ modelos no OpenRouter. Insira contagens de tokens, ordene por preço, filtre por provedor.",
+        badge: "new",
+      },
+      {
+        slug: "persona-picker",
+        title: "Seletor de Persona de IA",
+        category: "ai",
+        description:
+          "20 personas de prompt de sistema prontas para engenheiros, escritores e analistas. Copie em um clique ou salve as suas.",
+        badge: "new",
+      },
+      {
+        slug: "base64-converter",
+        title: "Conversor Base64",
+        category: "encoding",
+        description:
+          "Converta, valide e repare payloads Base64/Base64URL totalmente no lado do cliente.",
+      },
+      {
+        slug: "hash-generator",
+        title: "Gerador de Hash",
+        category: "hashing",
+        description:
+          "Gere e verifique hashes MD5, SHA-1, SHA-256, SHA-384 e SHA-512.",
+      },
+      {
+        slug: "image-optimizer",
+        title: "Otimizador de Imagens",
+        category: "imaging",
+        description:
+          "Converta imagens para WebP no navegador. Controle qualidade e redimensione — sem uploads.",
+      },
+      {
+        slug: "markdown-editor",
+        title: "Editor Markdown",
+        category: "writing",
+        description:
+          "Editor Markdown ao vivo com preview, exportação e atalhos de formatação.",
+      },
+      {
+        slug: "estimators",
+        title: "Estimativas",
+        category: "planning",
+        description:
+          "Ferramentas de estimativa de projetos e esforço para times de engenharia.",
+      },
+      {
+        slug: "log-viewer",
+        title: "Visualizador de Logs",
+        category: "devops",
+        description:
+          "Parse, filtre e inspecione arquivos de log estruturados diretamente no navegador.",
+      },
+      {
+        slug: "jwt-inspector",
+        title: "Inspector JWT",
+        category: "security",
+        description:
+          "Decodifique tokens JWT, inspecione claims e obtenha contagem regressiva de expiração com avisos de segurança.",
+      },
+      {
+        slug: "yaml-json",
+        title: "YAML ↔ JSON",
+        category: "devops",
+        description:
+          "Conversor bidirecional YAML e JSON com validação em tempo real. Sem servidor, sem logs.",
+      },
+      {
+        slug: "online-linters",
+        title: "Linters Online",
+        category: "linting",
+        description:
+          "Linter em tempo real para JSON, YAML, JavaScript e Markdown com Monaco Editor.",
+      },
+      {
+        slug: "diff-viewer",
+        title: "Diff Viewer",
+        category: "text",
+        description:
+          "Compare dois textos lado a lado ou unificado — linhas adicionadas, removidas e inalteradas destacadas.",
+      },
+    ],
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// Contact
+// ---------------------------------------------------------------------------
+export const contactT = {
+  en: {
+    label: "// contact",
+    headingPre: "Let's Build ",
+    headingHighlight: "Together?",
+    subtitle: "Tell us about your project. We'll respond within 24 hours.",
+    preferWriting: "Prefer writing first?",
+    formDescription:
+      "Send the project context, current constraints, and what kind of outcome you need. If scheduling is easier, the live calendar is available on the right.",
+    labelName: "Name",
+    labelEmail: "Email",
+    labelPhone: "Phone (Optional)",
+    labelMessage: "Message",
+    placeholderName: "Your name",
+    placeholderPhone: "+1 (555) 000-0000",
+    placeholderMessage: "Describe your project...",
+    btnSending: "Sending...",
+    btnSend: "Send Message",
+    successMsg:
+      "Thank you for contacting us! Message sent. We'll respond shortly.",
+    errorMsg:
+      "I'm sorry, due the high demand we can't meet your request at moment. Hope we can talk soon.",
+  },
+  pt: {
+    label: "// contato",
+    headingPre: "Vamos Construir ",
+    headingHighlight: "Juntos?",
+    subtitle: "Fale sobre o seu projeto. Respondemos em até 24 horas.",
+    preferWriting: "Prefere escrever primeiro?",
+    formDescription:
+      "Envie o contexto do projeto, restrições atuais e o tipo de resultado que você precisa. Se agendar for mais fácil, o calendário ao vivo está disponível ao lado.",
+    labelName: "Nome",
+    labelEmail: "E-mail",
+    labelPhone: "Telefone (Opcional)",
+    labelMessage: "Mensagem",
+    placeholderName: "Seu nome",
+    placeholderPhone: "+55 (21) 99999-9999",
+    placeholderMessage: "Descreva seu projeto...",
+    btnSending: "Enviando...",
+    btnSend: "Enviar Mensagem",
+    successMsg:
+      "Obrigado pelo contato! Mensagem enviada. Responderemos em breve.",
+    errorMsg:
+      "Pedimos desculpas, devido à alta demanda não podemos atender sua solicitação no momento. Esperamos conversar em breve.",
+  },
+} satisfies Record<Lang, object>;
+
+// ---------------------------------------------------------------------------
+// FAQ
+// ---------------------------------------------------------------------------
+export const faqT = {
+  en: { title: "Frequently Asked Questions" },
+  pt: { title: "Perguntas Frequentes" },
+} satisfies Record<Lang, object>;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,6 +13,7 @@ interface Props {
   robots?: string;
   schema?: Record<string, unknown> | Array<Record<string, unknown>>;
   pageData?: Record<string, unknown>;
+  htmlLang?: string;
 }
 
 const {
@@ -25,13 +26,14 @@ const {
   robots = "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1",
   schema,
   pageData,
+  htmlLang = "en",
 } = Astro.props;
 
 const keywordsString = Array.isArray(keywords) ? keywords.join(", ") : keywords;
 const schemaItems = Array.isArray(schema) ? schema : schema ? [schema] : [];
 ---
 
-<html lang="en" class="dark">
+<html lang={htmlLang} class="dark">
   <head>
     {pageData && <script is:inline define:vars={{ pageData }}>window.dataLayer=window.dataLayer||[];window.dataLayer.push(pageData);</script>}
     <!-- Google Tag Manager -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
-import HeroSection from "@/components/react/HeroSection";
-import ServicesSection from "@/components/react/ServicesSection";
-import CasesSection from "@/components/react/CasesSection";
-import AboutSection from "@/components/react/AboutSection";
-import TechSection from "@/components/react/TechSection";
-import ContactSection from "@/components/react/ContactSection";
-import ToolsSection from "@/components/react/ToolsSection";
-import FAQSection from "@/components/react/FAQSection";
+import HomePage from "@/components/react/HomePage";
 import { homeFAQ } from "@/data/faq";
 import { ORGANIZATION_ID, WEBSITE_ID, organizationSchema, websiteSchema } from "@/lib/schema";
 
@@ -102,12 +95,5 @@ const homepageSchema = [
   schema={homepageSchema}
   pageData={{ pageType: 'home' }}
 >
-  <HeroSection client:load />
-  <ServicesSection client:load />
-  <CasesSection client:load />
-  <AboutSection client:load />
-  <TechSection client:load />
-  <ToolsSection client:load />
-  <FAQSection client:load items={homeFAQ} />
-  <ContactSection client:load />
+  <HomePage lang="en" client:load />
 </Layout>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -1,0 +1,99 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import HomePage from "@/components/react/HomePage";
+import { homeFAQ_pt } from "@/data/faq";
+import { ORGANIZATION_ID, WEBSITE_ID, organizationSchema, websiteSchema } from "@/lib/schema";
+
+const homepageUrl = "https://huntermussel.com/pt/";
+const homepageSchema = [
+  organizationSchema({
+    description:
+      "HunterMussel ajuda empresas a construir software escalável, workflows de automação com IA, infraestrutura em nuvem e sistemas de SEO técnico.",
+    email: "contact@huntermussel.com",
+    founder: {
+      "@type": "Person",
+      name: "Iago Mussel",
+      url: "https://huntermussel.com/about/",
+    },
+    sameAs: [
+      "https://www.linkedin.com/in/iago-mussel/",
+      "https://github.com/iagomussel",
+    ],
+    areaServed: "BR",
+    knowsAbout: [
+      "automação com IA",
+      "desenvolvimento de software personalizado",
+      "engenharia DevOps",
+      "infraestrutura em nuvem",
+      "SEO técnico",
+    ],
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "sales",
+      email: "contact@huntermussel.com",
+      availableLanguage: ["Portuguese", "English"],
+    },
+  }),
+  websiteSchema(),
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Automação com IA, DevOps e Desenvolvimento de Software Personalizado",
+    url: homepageUrl,
+    description:
+      "HunterMussel ajuda empresas a construir software escalável, workflows de automação com IA, infraestrutura em nuvem e sistemas de SEO técnico.",
+    isPartOf: {
+      "@id": WEBSITE_ID,
+    },
+    mainEntity: {
+      "@id": ORGANIZATION_ID,
+    },
+    about: [
+      "automação com IA",
+      "engenharia DevOps",
+      "desenvolvimento de software personalizado",
+      "SEO técnico",
+    ],
+    inLanguage: "pt-BR",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: homeFAQ_pt.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  },
+];
+---
+
+<Layout
+  title="Automação com IA, DevOps & Desenvolvimento de Software"
+  description="HunterMussel ajuda empresas a construir software escalável, workflows de automação com IA, infraestrutura em nuvem e sistemas de SEO técnico."
+  canonicalUrl={homepageUrl}
+  htmlLang="pt-BR"
+  keywords={[
+    "agência de automação com IA",
+    "empresa de desenvolvimento de software",
+    "consultoria DevOps",
+    "infraestrutura em nuvem",
+    "SEO técnico",
+    "integração de IA",
+    "automação de workflows",
+    "arquitetura de software escalável",
+    "engenharia DevOps Brasil",
+    "HunterMussel",
+    "software house Brasil",
+    "agentes de IA",
+    "LLMOps",
+    "LGPD compliance",
+  ]}
+  schema={homepageSchema}
+  pageData={{ pageType: 'home', lang: 'pt' }}
+>
+  <HomePage lang="pt" client:load />
+</Layout>


### PR DESCRIPTION
- Create LangContext with LangProvider + useLang() hook
- Add src/data/translations.ts with full EN/PT strings for all sections
- Add homeFAQ_pt to faq.ts (10 translated FAQ items)
- Update all section components (Hero, Services, Cases, About, Tech, Tools, Contact) to consume useLang() — zero behavior change for existing EN users
- Create HomePage.tsx as a single React root wrapping all sections in LangProvider
- Add htmlLang prop to Layout.astro (defaults to 'en')
- Update index.astro to use <HomePage lang="en"> (identical output)
- Create src/pages/pt/index.astro at /pt/ with PT SEO meta, schema and <HomePage lang="pt">

https://claude.ai/code/session_01QoxsW9iFKQg8txzAoZB8oe