### PR TITLE
Update AdSense client ID in shared layouts

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -128,7 +128,7 @@ const pageSchema =
     <script type="application/ld+json" set:html={JSON.stringify(pageSchema)} />
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
     <!-- Google AdSense -->
-    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
+    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5924413044488831" crossorigin="anonymous"></script>
     <!-- End Google AdSense -->
   </head>
   <body class="bg-background text-foreground min-h-screen flex flex-col font-sans antialiased selection:bg-primary/20 selection:text-primary">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -80,7 +80,7 @@ const schemaItems = Array.isArray(schema) ? schema : schema ? [schema] : [];
     <meta name="twitter:site" content="@huntermussel" />
 
     <!-- Google AdSense -->
-    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX" crossorigin="anonymous"></script>
+    <script is:inline async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5924413044488831" crossorigin="anonymous"></script>
     <!-- End Google AdSense -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap-index.xml" />


### PR DESCRIPTION
### Motivation
- Enable the site to load the real Google AdSense script by replacing the placeholder publisher ID in the shared layouts.

### Description
- Replaced `ca-pub-XXXXXXXXXXXXXXXX` with `ca-pub-5924413044488831` in `src/layouts/Layout.astro` and `src/layouts/BaseLayout.astro` so both main pages and tool pages use the same AdSense script URL.

### Testing
- Ran `git diff -- src/layouts/Layout.astro src/layouts/BaseLayout.astro` and `git status --short`, then committed the change; both commands succeeded and no runtime/unit tests were executed because this is a configuration-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9e44d88d48326b14d3708946f1cad)