### PR TITLE
Improve chat widget XSS protection and worker rate-limiting/performance

### DIFF
--- a/public/chat-widget.js
+++ b/public/chat-widget.js
@@ -122,23 +122,27 @@
 
   // --- Render simple markdown (bold, links, lists) ---
   function renderMarkdown(text) {
-    return text
-      .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
-      .replace(
-        /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g,
-        '<a href="$2" target="_blank" rel="noopener">$1</a>'
-      )
-      .replace(
-        /(^|\n)- (.+)/g,
-        function (_, pre, item) { return pre + "\u2022 " + item; }
-      )
-      .replace(
-        /(?:^|\s)(https?:\/\/[^\s<]+)/g,
-        function (match, url) {
-          // Don't double-link URLs already in anchor tags
-          return ' <a href="' + url + '" target="_blank" rel="noopener">' + url + "</a>";
-        }
-      );
+    var escaped = escapeHtml(text || "");
+
+    escaped = escaped.replace(
+      /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+      function (_, label, url) {
+        return '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + label + "</a>";
+      }
+    );
+
+    escaped = escaped.replace(
+      /(^|[^"'>])(https?:\/\/[^\s<]+)/g,
+      function (_, prefix, url) {
+        return prefix + '<a href="' + url + '" target="_blank" rel="noopener noreferrer">' + url + "</a>";
+      }
+    );
+
+    return escaped
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/(^|\n)- (.+)/g, function (_, pre, item) {
+        return pre + "\u2022 " + item;
+      });
   }
 
   function buildWidget() {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -18,12 +18,37 @@ function corsHeaders(origin: string, allowedOrigin: string): Record<string, stri
   };
 }
 
+const MAX_REQUEST_MESSAGES = 20;
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
+
 function sanitizeInput(text: string): string {
   return text
     .replace(/<[^>]*>/g, "")
     .replace(/[^\p{L}\p{N}\p{P}\p{Z}\p{S}]/gu, "")
     .trim()
     .slice(0, 2000);
+}
+
+function isValidChatRequest(body: unknown): body is ChatRequest {
+  if (!body || typeof body !== "object") return false;
+
+  const requestBody = body as ChatRequest;
+  if (
+    typeof requestBody.sessionId !== "string" ||
+    !SESSION_ID_PATTERN.test(requestBody.sessionId) ||
+    !Array.isArray(requestBody.messages) ||
+    requestBody.messages.length === 0 ||
+    requestBody.messages.length > MAX_REQUEST_MESSAGES
+  ) {
+    return false;
+  }
+
+  return requestBody.messages.every(
+    (message) =>
+      (message.role === "user" || message.role === "assistant") &&
+      typeof message.content === "string" &&
+      message.content.trim().length > 0
+  );
 }
 
 export default {
@@ -65,9 +90,9 @@ async function handleChat(
     });
   }
 
-  if (!body.messages?.length || !body.sessionId) {
+  if (!isValidChatRequest(body)) {
     return new Response(
-      JSON.stringify({ error: "Missing messages or sessionId" }),
+      JSON.stringify({ error: "Invalid chat request" }),
       {
         status: 400,
         headers: { ...headers, "Content-Type": "application/json" },
@@ -76,7 +101,7 @@ async function handleChat(
   }
 
   const clientIp = request.headers.get("CF-Connecting-IP") || "unknown";
-  trackSession(clientIp);
+  trackSession(body.sessionId, clientIp);
 
   const rateCheck = checkRateLimit(body.sessionId, clientIp, env);
   if (!rateCheck.allowed) {

--- a/worker/src/rag.ts
+++ b/worker/src/rag.ts
@@ -1,10 +1,15 @@
 import type { Env, SearchResult, ContentChunk } from "./types";
 
+interface EmbeddingResponse {
+  data: number[][];
+}
+
 export async function embedQuery(text: string, ai: Ai): Promise<number[]> {
-  const result = await ai.run("@cf/baai/bge-base-en-v1.5", {
+  const result = (await ai.run("@cf/baai/bge-base-en-v1.5", {
     text: [text],
-  });
-  return result.data[0];
+  })) as EmbeddingResponse;
+
+  return result.data[0] || [];
 }
 
 export async function searchContent(
@@ -19,33 +24,33 @@ export async function searchContent(
     returnMetadata: "all",
   });
 
-  const results: SearchResult[] = [];
+  const results = await Promise.all(
+    matches.matches
+      .filter((match) => match.score >= minScore)
+      .map(async (match): Promise<SearchResult | null> => {
+        const metadata = match.metadata as Record<string, string> | undefined;
+        if (!metadata) return null;
 
-  for (const match of matches.matches) {
-    if (match.score < minScore) continue;
+        let content = metadata.content || "";
 
-    const metadata = match.metadata as Record<string, string> | undefined;
-    if (!metadata) continue;
+        if (!content && match.id) {
+          const stored = await contentStore.get(`chunks/${match.id}.json`);
+          if (stored) {
+            const chunk: ContentChunk = await stored.json();
+            content = chunk.content;
+          }
+        }
 
-    let content = metadata.content || "";
+        return {
+          id: match.id,
+          content,
+          sourceTitle: metadata.sourceTitle || "HunterMussel",
+          sourceUrl: metadata.sourceUrl || "https://huntermussel.com",
+          sourceType: (metadata.sourceType as SearchResult["sourceType"]) || "homepage",
+          score: match.score,
+        };
+      })
+  );
 
-    if (!content && match.id) {
-      const stored = await contentStore.get(`chunks/${match.id}.json`);
-      if (stored) {
-        const chunk: ContentChunk = await stored.json();
-        content = chunk.content;
-      }
-    }
-
-    results.push({
-      id: match.id,
-      content,
-      sourceTitle: metadata.sourceTitle || "HunterMussel",
-      sourceUrl: metadata.sourceUrl || "https://huntermussel.com",
-      sourceType: (metadata.sourceType as SearchResult["sourceType"]) || "homepage",
-      score: match.score,
-    });
-  }
-
-  return results;
+  return results.filter((result): result is SearchResult => result !== null);
 }

--- a/worker/src/rate-limit.ts
+++ b/worker/src/rate-limit.ts
@@ -5,20 +5,54 @@ interface RateLimitResult {
   reason?: string;
 }
 
-const sessionMessageCounts = new Map<string, number>();
-const ipSessionCounts = new Map<string, { count: number; resetAt: number }>();
+interface ExpiringCounter {
+  count: number;
+  resetAt: number;
+}
+
+const sessionMessageCounts = new Map<string, ExpiringCounter>();
+const ipSessionCounts = new Map<string, ExpiringCounter>();
+const seenSessions = new Map<string, number>();
+
+const HOUR_MS = 60 * 60 * 1000;
+const SESSION_TTL_MS = 24 * HOUR_MS;
+const MAX_TRACKED_KEYS = 5000;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function pruneExpired<T extends ExpiringCounter | number>(
+  map: Map<string, T>,
+  now: number
+): void {
+  if (map.size < MAX_TRACKED_KEYS) return;
+
+  for (const [key, value] of map) {
+    const expiresAt = typeof value === "number" ? value : value.resetAt;
+    if (now >= expiresAt) {
+      map.delete(key);
+    }
+  }
+}
 
 export function checkRateLimit(
   sessionId: string,
   clientIp: string,
   env: Env
 ): RateLimitResult {
-  const maxMessages = parseInt(env.MAX_MESSAGES_PER_SESSION) || 20;
-  const maxSessions = parseInt(env.MAX_SESSIONS_PER_HOUR) || 100;
+  const maxMessages = parsePositiveInt(env.MAX_MESSAGES_PER_SESSION, 20);
+  const maxSessions = parsePositiveInt(env.MAX_SESSIONS_PER_HOUR, 100);
+  const now = Date.now();
+
+  pruneExpired(sessionMessageCounts, now);
+  pruneExpired(ipSessionCounts, now);
+  pruneExpired(seenSessions, now);
 
   // Check per-session message count
-  const messageCount = sessionMessageCounts.get(sessionId) || 0;
-  if (messageCount >= maxMessages) {
+  const messageCounter = sessionMessageCounts.get(sessionId);
+  if (messageCounter && now < messageCounter.resetAt && messageCounter.count >= maxMessages) {
     return {
       allowed: false,
       reason:
@@ -27,32 +61,41 @@ export function checkRateLimit(
   }
 
   // Check per-IP session count
-  const now = Date.now();
   const ipData = ipSessionCounts.get(clientIp);
-  if (ipData && now < ipData.resetAt) {
-    if (ipData.count >= maxSessions) {
-      return {
-        allowed: false,
-        reason: "Too many sessions. Please try again later.",
-      };
-    }
+  if (ipData && now < ipData.resetAt && ipData.count >= maxSessions) {
+    return {
+      allowed: false,
+      reason: "Too many sessions. Please try again later.",
+    };
   }
 
   return { allowed: true };
 }
 
 export function incrementMessageCount(sessionId: string): void {
-  const current = sessionMessageCounts.get(sessionId) || 0;
-  sessionMessageCounts.set(sessionId, current + 1);
+  const now = Date.now();
+  const current = sessionMessageCounts.get(sessionId);
+
+  if (!current || now >= current.resetAt) {
+    sessionMessageCounts.set(sessionId, { count: 1, resetAt: now + SESSION_TTL_MS });
+    return;
+  }
+
+  current.count++;
 }
 
-export function trackSession(clientIp: string): void {
+export function trackSession(sessionId: string, clientIp: string): void {
   const now = Date.now();
-  const hourMs = 60 * 60 * 1000;
-  const ipData = ipSessionCounts.get(clientIp);
+  const sessionKey = `${clientIp}:${sessionId}`;
+  const seenUntil = seenSessions.get(sessionKey);
 
+  if (seenUntil && now < seenUntil) return;
+
+  seenSessions.set(sessionKey, now + HOUR_MS);
+
+  const ipData = ipSessionCounts.get(clientIp);
   if (!ipData || now >= ipData.resetAt) {
-    ipSessionCounts.set(clientIp, { count: 1, resetAt: now + hourMs });
+    ipSessionCounts.set(clientIp, { count: 1, resetAt: now + HOUR_MS });
   } else {
     ipData.count++;
   }


### PR DESCRIPTION
### Motivation
- Reduce XSS and tabnabbing risk in the client chat widget by ensuring assistant content is escaped before applying formatting and links. 
- Harden and validate incoming chat requests to avoid malformed or abusive payloads reaching RAG and OpenAI calls. 
- Make in-memory rate-limiting more robust and memory-friendly while reducing unnecessary increments per session and parallelizing R2 I/O for RAG to improve performance.

### Description
- Make `renderMarkdown` safer in `public/chat-widget.js` by escaping content first, applying a whitelist of formatting, and adding `rel="noopener noreferrer"` to external links. 
- Add request validation in `worker/src/index.ts` with `isValidChatRequest`, `MAX_REQUEST_MESSAGES`, and `SESSION_ID_PATTERN` to verify `sessionId`, roles, message counts, and non-empty content before further processing. 
- Improve `worker/src/rate-limit.ts` to use expiring counters, a `seenSessions` map for unique session-per-IP counting, pruning of expired keys, and safe parsing of env vars via `parsePositiveInt`. 
- Update `worker/src/rag.ts` to type the embedding response and parallelize missing-chunk loads from R2 with `Promise.all`, returning only matches above `minScore`.

### Testing
- Typecheck with `pnpm exec tsc --noEmit -p worker/tsconfig.json`, which succeeded. 
- Unit tests via `npm test` completed successfully (tests passed). 
- `npm run build` was attempted but failed in this environment because Astro/Vite could not resolve the `vite` module. 
- Running `npm test -- --runInBand` is not supported by Vitest 4 and failed due to the unknown `--runInBand` option.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c995dfe5883269cec9bd35a34406a)